### PR TITLE
Allow to set meta title without prefix

### DIFF
--- a/lib/meta_tags/view_helper.rb
+++ b/lib/meta_tags/view_helper.rb
@@ -150,7 +150,7 @@ module MetaTags
       prefix = meta_tags[:prefix] === false ? '' : (meta_tags[:prefix] || ' ')
 
       # Separator
-      separator = meta_tags[:separator].blank? ? '|' : meta_tags[:separator]
+      separator = meta_tags[:separator] || '|'
 
       # Suffix (trailing space)
       suffix = meta_tags[:suffix] === false ? '' : (meta_tags[:suffix] || ' ')


### PR DESCRIPTION
Currently where is no way to setup meta title without prefix, because separator is always present. So i have changed default separator assign to allow this:
set_meta_tags :site => '', :prefix => false, :separator => '', :suffix => false
