### PR TITLE
fix string encoding

### DIFF
--- a/lib/meta_tags/view_helper.rb
+++ b/lib/meta_tags/view_helper.rb
@@ -211,7 +211,7 @@ module MetaTags
       # canonical
       result << tag(:link, :rel => :canonical, :href => meta_tags[:canonical]) unless meta_tags[:canonical].blank?
 
-      result = result.join("\n")
+      result = result.map{|s| s.force_encoding('UTF-8') }.join("\n")
       result.respond_to?(:html_safe) ? result.html_safe : result
     end
 


### PR DESCRIPTION
On 1.9.3-p0 I had some troubles with utf-8 support my rails 3.2.1 project wouldn't work without that fix
