### PR TITLE
OpenGraph Array, String & Symbol Support

### DIFF
--- a/lib/meta_tags/view_helper.rb
+++ b/lib/meta_tags/view_helper.rb
@@ -29,8 +29,19 @@ module MetaTags
       self.meta_tags.deep_merge! normalize_open_graph(meta_tags)
     end
     
+    # Set meta tag for the page.
+    #
+    # @param [String, Symbol] propery Property of meta tag.
+    # @param [String] value Content of meta tag.
+    #
+    # @example
+    #   set_meta_tag :custom_symbol, 'value'
+    #   set_meta_tag "custom_tag", 'value'
+    #
+    # @see #display_meta_tags
+    #
     def set_meta_tag(property, value)
-      self.meta_tags[property] = value
+      self.meta_tags[property.to_s] = value
     end
 
     # Set the page title and return it back.
@@ -185,6 +196,7 @@ module MetaTags
 
       # Open Graph
       (meta_tags[:open_graph] || {}).each do |property, content|
+        # if an array is passed in, display multiple meta tags with the same property
         if content.kind_of? Array
           content.each do |c|
             result << tag(:meta, :property => "og:#{property}", :content => c)

--- a/spec/meta_tags_spec.rb
+++ b/spec/meta_tags_spec.rb
@@ -336,6 +336,34 @@ describe MetaTags::ViewHelper do
         content.should include('<meta content="Facebook Share Description" property="og:description" />')
       end
     end
+    
+    it 'should display meta tags for specified string' do
+      subject.set_meta_tag "custom_tag", "value"
+      subject.display_meta_tags(:site => 'someSite').tap do |content|
+        content.should include('<meta content="value" property="custom_tag" />')
+      end
+    end
+    
+    it 'should display meta tags for specified symbol' do
+      subject.set_meta_tag :custom_symbol, "value"
+      subject.display_meta_tags(:site => 'someSite').tap do |content|
+        content.should include('<meta content="value" property="custom_symbol" />')
+      end
+    end
+    
+    it 'should display multiple meta tags for arrays specified with :og' do
+      subject.set_meta_tags(:og => {
+        :title       => 'Facebook Share Title',
+        :description => 'Facebook Share Description',
+        :image => ["image_url1", "image_url2"]
+      })
+      subject.display_meta_tags(:site => 'someSite').tap do |content|
+        content.should include('<meta content="Facebook Share Title" property="og:title" />')
+        content.should include('<meta content="Facebook Share Description" property="og:description" />')
+        content.should include('<meta content="image_url1" property="og:image" />')
+        content.should include('<meta content="image_url2" property="og:image" />')
+      end
+    end
 
     it 'should use deep merge when displaying open graph meta tags' do
       subject.set_meta_tags(:og => { :title => 'Facebook Share Title' })


### PR DESCRIPTION
Added support for multiple opengraph meta tag values by passing in an array.
Added support for single meta tags using a symbol or string
