### PR TITLE
Only add OpenGraph tags if content is provided

### DIFF
--- a/lib/meta_tags/view_helper.rb
+++ b/lib/meta_tags/view_helper.rb
@@ -175,8 +175,8 @@ module MetaTags
         content = [meta_tags[:noindex] && 'noindex', meta_tags[:nofollow] && 'nofollow'].compact.join(', ')
         result << tag(:meta, :name => noindex_name, :content => content) unless content.blank?
       else
-        result << tag(:meta, :name => noindex_name,  :content => 'noindex')  if meta_tags[:noindex]
-        result << tag(:meta, :name => nofollow_name, :content => 'nofollow') if meta_tags[:nofollow]
+        result << tag(:meta, :name => noindex_name,  :content => 'noindex')  if meta_tags[:noindex] && meta_tags[:noindex] != false
+        result << tag(:meta, :name => nofollow_name, :content => 'nofollow') if meta_tags[:nofollow] && meta_tags[:nofollow] != false
       end
 
       # Open Graph

--- a/spec/meta_tags_spec.rb
+++ b/spec/meta_tags_spec.rb
@@ -248,6 +248,12 @@ describe MetaTags::ViewHelper do
     it 'should display nothing by default' do
       subject.display_meta_tags(:site => 'someSite').should_not include('<meta content="noindex"')
     end
+
+    it "should display nothing if given false" do
+      subject.set_meta_tags(:noindex => false)
+      subject.display_meta_tags(:site => 'someSite').should_not include('<meta content="robots"')
+      subject.display_meta_tags(:site => 'someSite').should_not include('<meta content="noindex"')
+    end
   end
 
   context 'displaying nofollow' do


### PR DESCRIPTION
Until now you always got all OpenGraph tags you provided which led to empty tags if there was no content. This commit fixes this.
