### PR TITLE
Adding prev and next meta tags

### DIFF
--- a/lib/meta_tags/view_helper.rb
+++ b/lib/meta_tags/view_helper.rb
@@ -2,6 +2,8 @@ module MetaTags
   # Contains methods to use in views and helpers.
   #
   module ViewHelper
+    LINK_TAGS = [:canonical, :prev, :next]
+
     # Get meta tags for the page.
     def meta_tags
       @meta_tags ||= HashWithIndifferentAccess.new
@@ -142,6 +144,8 @@ module MetaTags
     # @option default [Boolean, String] :noindex (false) add noindex meta tag; when true, 'robots' will be used, otherwise the string will be used;
     # @option default [Boolean, String] :nofollow (false) add nofollow meta tag; when true, 'robots' will be used, otherwise the string will be used;
     # @option default [String] :canonical (nil) add canonical link tag.
+    # @option default [String] :prev (nil) add prev link tag.
+    # @option default [String] :next (nil) add next link tag.
     # @option default [Hash] :open_graph ({}) add Open Graph meta tags.
     # @return [String] HTML meta tags to render in HEAD section of the
     #   HTML document.
@@ -190,9 +194,11 @@ module MetaTags
         end
       end
 
-      # canonical
-      result << tag(:link, :rel => :canonical, :href => meta_tags[:canonical]) unless meta_tags[:canonical].blank?
-      meta_tags.delete(:canonical)
+      # canonical, prev and next
+      LINK_TAGS.each do |tag_name|
+        result << tag(:link, :rel => tag_name, :href => meta_tags[tag_name]) unless meta_tags[tag_name].blank?
+        meta_tags.delete(tag_name)
+      end
 
       # user defined
       meta_tags.each do |name, data|

--- a/spec/meta_tags_spec.rb
+++ b/spec/meta_tags_spec.rb
@@ -339,6 +339,36 @@ describe MetaTags::ViewHelper do
     end
   end
 
+  context 'displaying prev url' do
+    it 'should not display prev url by default' do
+      subject.display_meta_tags(:site => 'someSite').should_not include('<link href="http://example.com/base/url" rel="prev" />')
+    end
+
+    it 'should display prev url when "set_meta_tags" used' do
+      subject.set_meta_tags(:prev => 'http://example.com/base/url')
+      subject.display_meta_tags(:site => 'someSite').should include('<link href="http://example.com/base/url" rel="prev" />')
+    end
+
+    it 'should display default prev url' do
+      subject.display_meta_tags(:site => 'someSite', :prev => 'http://example.com/base/url').should include('<link href="http://example.com/base/url" rel="prev" />')
+    end
+  end
+
+  context 'displaying next url' do
+    it 'should not display next url by default' do
+      subject.display_meta_tags(:site => 'someSite').should_not include('<link href="http://example.com/base/url" rel="next" />')
+    end
+
+    it 'should display next url when "set_meta_tags" used' do
+      subject.set_meta_tags(:next => 'http://example.com/base/url')
+      subject.display_meta_tags(:site => 'someSite').should include('<link href="http://example.com/base/url" rel="next" />')
+    end
+
+    it 'should display default next url' do
+      subject.display_meta_tags(:site => 'someSite', :next => 'http://example.com/base/url').should include('<link href="http://example.com/base/url" rel="next" />')
+    end
+  end
+
   context 'displaying Open Graph meta tags' do
     it 'should display meta tags specified with :open_graph' do
       subject.set_meta_tags(:open_graph => {


### PR DESCRIPTION
Google's recommended pagination tags.

http://googlewebmastercentral.blogspot.com/2011/09/pagination-with-relnext-and-relprev.html
