### PR TITLE
Call #to_s on title in #normalize_title.

### DIFF
--- a/lib/meta_tags/view_helper.rb
+++ b/lib/meta_tags/view_helper.rb
@@ -282,7 +282,7 @@ module MetaTags
       end
 
       def normalize_title(title)
-        Array(title).map { |t| h(strip_tags(t)) }
+        Array(title.to_s).map { |t| h(strip_tags(t)) }
       end
 
       def normalize_description(description)


### PR DESCRIPTION
This is to ensure to have a string object that works as expected with the Array() call.
