### PR TITLE
Add Google "author" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,14 @@ Further reading:
 
 * [About rel="author"](https://support.google.com/webmasters/answer/2539557?hl=en)
 
+### Publisher links
+
+Link to your Google+ profile using rel="publisher"
+
+    set_meta_tags :publisher => "http://yourgplusprofile.com/profile/url"
+    # <link rel="publisher" href="http://yourgplusprofile.com/profile/url" />
+
+
 ### Pagination links
 
 Previous and next links indicate indicate the relationship between individual
@@ -315,6 +323,7 @@ Use these options to customize the title format:
 * `:nofollow` — add nofollow meta tag; when true, 'robots' will be used, otherwise the string will be used;
 * `:canonical` — add canonical link tag;
 * `:author` — add author link tag;
+* `:publisher` — add publisher link tag;
 * `:prev` — add prev link tag;
 * `:prev` — add next link tag;
 * `:og` — add Open Graph tags (Hash);

--- a/lib/meta_tags/view_helper.rb
+++ b/lib/meta_tags/view_helper.rb
@@ -214,8 +214,8 @@ module MetaTags
         end
       end
 
-      # canonical, prev, next and author
-      [ :canonical, :prev, :next, :author ].each do |tag_name|
+      # canonical, prev, next and author, :publisher
+      [ :canonical, :prev, :next, :author, :publisher ].each do |tag_name|
         next unless href = meta_tags.delete(tag_name)
         result << tag(:link, :rel => tag_name, :href => href)
       end

--- a/spec/meta_tags_spec.rb
+++ b/spec/meta_tags_spec.rb
@@ -367,6 +367,12 @@ describe MetaTags::ViewHelper do
     end
   end
 
+  context 'displaying publisher link' do
+    it 'should display publisher link when "set_meta_tags" used' do
+      subject.set_meta_tags(:publisher => 'http://plus.google.com/myprofile_url')
+      subject.display_meta_tags(:site => 'someSite').should include('<link href="http://plus.google.com/myprofile_url" rel="publisher" />')
+    end
+  end
 
   context 'displaying prev url' do
     it 'should not display prev url by default' do


### PR DESCRIPTION
can do this now :
<link href="https://plus.google.com/109412257237874861202? rel=author" />

with :
set_meta_tags author: "https://plus.google.com/109412257237874861202"

more info :
https://support.google.com/webmasters/answer/2539557?hl=en
