### PR TITLE
Implement mirrored values inside namespaces declared as hashes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,27 @@ Keywords can be passed as string of comma-separated values, or as an array:
 
 Description is a string (HTML will be stripped from output string).
 
+### Mirrored values
+
+Sometimes, it is desirable to mirror meta tag values down into namespaces. A
+common use case is when you want open graph's `og:title` to be identical to 
+the `title`.
+
+Say, you have the following in your application layout:
+
+    display_meta_tags :og => {
+      :title => :title
+    }
+
+The value of `og[:title]` is a symbol and therefore references the value of the
+top level `title` meta tag. With the following in any view:
+
+    title 'my great view'
+    
+You get this open graph meta tag for free:
+
+    <meta property="og:title" content="my great view"></meta>
+
 ### Using with pjax
 
 [jQuery.pjax](https://github.com/defunkt/jquery-pjax) is a nice solution for navigation

--- a/lib/meta_tags/view_helper.rb
+++ b/lib/meta_tags/view_helper.rb
@@ -267,7 +267,7 @@ module MetaTags
         result = []
         if content.is_a?(Hash)
           content.each do |key, value|
-            result.concat process_tree("#{property}:#{key}", value)
+            result.concat process_tree("#{property}:#{key}", value.is_a?(Symbol) ? meta_tags[value] : value)
           end
         else
           Array(content).each do |c|

--- a/spec/meta_tags_spec.rb
+++ b/spec/meta_tags_spec.rb
@@ -216,15 +216,15 @@ describe MetaTags::ViewHelper do
       subject.display_meta_tags.should eq('')
     end
 
-    it 'should display keywords when "keywords" used' do
-      subject.keywords('some-keywords')
-      subject.display_meta_tags(:site => 'someSite').should include('<meta content="some-keywords" name="keywords" />')
-    end
+     it 'should display keywords when "keywords" used' do
+       subject.keywords('some-keywords')
+       subject.display_meta_tags(:site => 'someSite').should include('<meta content="some-keywords" name="keywords" />')
+     end
 
-    it 'should display keywords when "set_meta_tags" used' do
-      subject.set_meta_tags(:keywords => 'some-keywords')
-      subject.display_meta_tags(:site => 'someSite').should include('<meta content="some-keywords" name="keywords" />')
-    end
+     it 'should display keywords when "set_meta_tags" used' do
+       subject.set_meta_tags(:keywords => 'some-keywords')
+       subject.display_meta_tags(:site => 'someSite').should include('<meta content="some-keywords" name="keywords" />')
+     end
 
     it 'should display default keywords' do
       subject.display_meta_tags(:site => 'someSite', :keywords => 'some-keywords').should include('<meta content="some-keywords" name="keywords" />')
@@ -456,6 +456,13 @@ describe MetaTags::ViewHelper do
       subject.display_meta_tags(:site => 'someSite').tap do |content|
         content.should_not include('<meta content="" property="og:title" />')
         content.should_not include('<meta content="" property="og:description" />')
+      end
+    end
+
+    it "should display mirrored content" do
+      subject.set_meta_tags(:title => 'someTitle')
+      subject.display_meta_tags(:open_graph => { :title => :title }).tap do |content|
+        content.should include('<meta content="someTitle" property="og:title" />')
       end
     end
   end


### PR DESCRIPTION
This is a new incarnation of the outdated pull request #15 of @lehni - this time with an example in the README and specs.

It shouldn't break any existing code since it's very unlikely anybody used symbols as meta tag values until now. But it DRYes up quite a bit of duplication on open graphs and twitter card declarations of my apps.

Thanks for considering this little feature!
