### PR TITLE
Add support for OpenSearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,22 @@ Further reading:
 * [Meta refresh](http://en.wikipedia.org/wiki/Meta_refresh)
 * [What is the Meta Refresh Tag](http://webdesign.about.com/od/metataglibraries/a/aa080300a.htm)
 
+
+### Open Search
+
+Open Search link element to describe a search engine in a standard and accessible format.
+
+    set_meta_tags :open_search => {
+      :title => "Open Search",
+      :href => "/opensearch.xml"
+    }
+    # <link href="/opensearch.xml" rel="search" title="Open Search" type="application/opensearchdescription+xml" />
+
+Further reading:
+
+* [OpenSearch specs] http://www.opensearch.org/Specifications/OpenSearch/1.1
+* [OpenSearch wiki] http://en.wikipedia.org/wiki/OpenSearch
+
 ### Hashes
 
 Any namespace can be built just passing any symbol name and a Hash. For example:

--- a/lib/meta_tags/renderer.rb
+++ b/lib/meta_tags/renderer.rb
@@ -25,6 +25,7 @@ module MetaTags
       render_refresh(tags)
       render_noindex(tags)
       render_alternate(tags)
+      render_open_search(tags)
       render_links(tags)
 
       render_hash(tags, :og, :name_key => :property)
@@ -97,6 +98,21 @@ module MetaTags
       if alternate = meta_tags.extract(:alternate)
         alternate.each do |hreflang, href|
           tags << Tag.new(:link, :rel => 'alternate', :href => href, :hreflang => hreflang) if href.present?
+        end
+      end
+    end
+
+    # Renders open_search link tag.
+    #
+    # @param [Array<Tag>] tags a buffer object to store tag in.
+    #
+    def render_open_search(tags)
+      if open_search = meta_tags.extract(:open_search)
+        href = open_search[:href]
+        title = open_search[:title]
+        if href.present?
+          type = "application/opensearchdescription+xml"
+          tags << Tag.new(:link, :rel => 'search', :type => type, :href => href, :title => title)
         end
       end
     end

--- a/lib/meta_tags/view_helper.rb
+++ b/lib/meta_tags/view_helper.rb
@@ -164,6 +164,7 @@ module MetaTags
     # @option default [String] :publisher (nil) add publisher link tag.
     # @option default [String, Integer] :refresh (nil) meta refresh tag;
     # @option default [Hash] :open_graph ({}) add Open Graph meta tags.
+    # @option default [Hash] :open_search ({}) add Open Search link tag.
     # @return [String] HTML meta tags to render in HEAD section of the
     #   HTML document.
     #

--- a/spec/view_helper/open_search_spec.rb
+++ b/spec/view_helper/open_search_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe MetaTags::ViewHelper, 'displaying Open Search meta tags' do
+  subject { ActionView::Base.new }
+
+  it 'should display meta tags specified with :open_search' do
+    subject.set_meta_tags(:open_search => {
+        :title => 'Open Search Title',
+        :href  => '/open_search_path.xml'
+    })
+    subject.display_meta_tags(:site => 'someSite').tap do |meta|
+      type = "application/opensearchdescription+xml"
+      link = "<link href=\"/open_search_path.xml\" rel=\"search\" title=\"Open Search Title\" type=\"#{type}\" />"
+      expect(meta).to include(link)
+    end
+  end
+
+  it 'should not display meta tags without content' do
+    subject.set_meta_tags(:open_search => {
+        :title => '',
+        :href  => ''
+    })
+    subject.display_meta_tags(:site => 'someSite').tap do |meta|
+      type = "application/opensearchdescription+xml"
+      link = "<link href=\"/\" rel=\"search\" title=\"\" type=\"#{type}\" />"
+      expect(meta).to_not include(link)
+    end
+  end
+
+end


### PR DESCRIPTION
Added support for **Open Search**.

It is used to describe a search engine.

* [OpenSearch specs] http://www.opensearch.org/Specifications/OpenSearch/1.1
* [OpenSearch wiki] http://en.wikipedia.org/wiki/OpenSearch