### PR TITLE
Can configure description truncation length

### DIFF
--- a/lib/meta_tags.rb
+++ b/lib/meta_tags.rb
@@ -3,6 +3,13 @@ require 'action_view'
 
 # MetaTags gem namespace.
 module MetaTags
+  def self.truncate_description_at_length=(truncate_at)
+    @truncate_description_at_length = truncate_at
+  end
+
+  def self.truncate_description_at_length
+    @truncate_description_at_length ||= 200
+  end
 end
 
 require 'meta_tags/version'

--- a/lib/meta_tags/text_normalizer.rb
+++ b/lib/meta_tags/text_normalizer.rb
@@ -18,7 +18,8 @@ module MetaTags
     #
     def self.normalize_description(description)
       return '' if description.blank?
-      helpers.truncate(cleanup_string(description), :length => 200)
+      helpers.truncate(cleanup_string(description),
+                       :length => MetaTags.truncate_description_at_length)
     end
 
     # Normalize keywords value.

--- a/spec/view_helper/description_spec.rb
+++ b/spec/view_helper/description_spec.rb
@@ -47,9 +47,21 @@ describe MetaTags::ViewHelper, 'displaying description' do
     end
   end
 
-  it 'should truncate correctly' do
+  it 'should truncate at 200 chars, by default' do
     subject.display_meta_tags(:site => 'someSite', :description => "Lorem ipsum dolor sit amet, consectetuer sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.").tap do |meta|
       expect(meta).to include('<meta content="Lorem ipsum dolor sit amet, consectetuer sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dol..." name="description" />')
     end
   end
+
+  it 'should allow the default truncation length to be overridden' do
+    begin
+      MetaTags.truncate_description_at_length = 5
+      subject.display_meta_tags(:site => 'someSite', :description => "012345679").tap do |meta|
+        expect(meta).to include('<meta content="01..." name="description" />')
+      end
+    ensure
+      MetaTags.truncate_description_at_length = nil
+    end
+  end
+
 end


### PR DESCRIPTION
The length at which meta description was truncated was hard-coded to 200
chars. This can now be configured using
MetaTags#truncate_description_at_length= . It still defaults to 200
chars for backward compatibility.

Note that currently a large number of specs fail in Rails/Actionpack
4.2. See issue https://github.com/kpumuk/meta-tags/issues/74, on the original repo, which includes a
workaround.