### PR TITLE
Update MetaTags::TextNormalizer.strip_tags to handle '&amp;'

### DIFF
--- a/lib/meta_tags/text_normalizer.rb
+++ b/lib/meta_tags/text_normalizer.rb
@@ -45,7 +45,7 @@ module MetaTags
     # @return [String] string with no HTML tags.
     #
     def self.strip_tags(string)
-      helpers.strip_tags(string)
+      helpers.strip_tags(string).gsub("&amp;", "&")
     end
 
     # This method returns a html safe string similar to what <tt>Array#join</tt>


### PR DESCRIPTION
I have a couple of titles and such that use the '&' character, which ends up being displayed as '&amp;' in the browser.