### PR TITLE
Removes alias_method_chain

### DIFF
--- a/lib/meta_tags/controller_helper.rb
+++ b/lib/meta_tags/controller_helper.rb
@@ -12,20 +12,15 @@ module MetaTags
   module ControllerHelper
     extend ActiveSupport::Concern
 
-    included do
-      alias_method_chain :render, :meta_tags
-    end
-
     # Processes the <tt>@page_title</tt>, <tt>@page_keywords</tt>, and
     # <tt>@page_description</tt> instance variables and calls +render+.
-    def render_with_meta_tags(*args, &block)
+    def render(*args, &block)
       self.meta_tags[:title]       = @page_title       if @page_title
       self.meta_tags[:keywords]    = @page_keywords    if @page_keywords
       self.meta_tags[:description] = @page_description if @page_description
 
-      render_without_meta_tags(*args, &block)
+      super(*args, &block)
     end
-    protected :render_with_meta_tags
 
     # Set meta tags for the page.
     #


### PR DESCRIPTION
```alais_method_chain``` has been deprecated, and is causing this gem to break when used with ```turbolinks``` (see [this issue](https://github.com/rails/turbolinks/issues/620)).

I have corrected the issue on my master.