### PR TITLE
Removed Google "author" and "publisher" links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.1.1 (November 05, 2015)
+
+Features:
+
+  - Removed Google "author" and "publisher" links, as Google deprecated these options (https://support.google.com/webmasters/answer/6083347?hl=en)
+
 ## 2.1.0 (October 6, 2015)
 
 Changes:

--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,4 @@ end
 
 group :test do
   gem 'codeclimate-test-reporter', require: false
-  gem 'rspec-html-matchers'
 end

--- a/README.md
+++ b/README.md
@@ -146,26 +146,6 @@ Further reading:
 * [Favicon](https://www.wikiwand.com/en/Favicon)
 * [Touch Icons](https://mathiasbynens.be/notes/touch-icons)
 
-### Author links
-
-Link to your Google+ profile using rel="author"
-
-    set_meta_tags author: "http://yourgplusprofile.com/profile/url"
-    # <link rel="author" href="http://yourgplusprofile.com/profile/url" />
-
-Further reading:
-
-* [About rel="author"](https://support.google.com/webmasters/answer/2539557?hl=en)
-
-### Publisher links
-
-Link to your Google+ profile using rel="publisher"
-
-    set_meta_tags publisher: "http://yourgplusprofile.com/profile/url"
-    # <link rel="publisher" href="http://yourgplusprofile.com/profile/url" />
-
-* [Link to your website](https://support.google.com/plus/answer/1713826?hl=en)
-* [The Difference Between rel=author & rel=publisher](http://www.websitemagazine.com/content/blogs/posts/archive/2013/02/05/the-difference-between-rel-author-amp-rel-publisher.aspx)
 
 ### Multi-regional and multilingual URLs, RSS and mobile links
 
@@ -456,8 +436,7 @@ Use these options to customize the title format:
 * `:noindex` — add noindex meta tag; when true, 'robots' will be used, otherwise the string will be used;
 * `:nofollow` — add nofollow meta tag; when true, 'robots' will be used, otherwise the string will be used;
 * `:canonical` — add canonical link tag;
-* `:author` — add author link tag;
-* `:publisher` — add publisher link tag;
+* `:author` — add author meta tag;
 * `:prev` — add prev link tag;
 * `:next` — add next link tag;
 * `:og` — add Open Graph tags (Hash);

--- a/lib/meta_tags/renderer.rb
+++ b/lib/meta_tags/renderer.rb
@@ -147,7 +147,7 @@ module MetaTags
     # @param [Array<Tag>] tags a buffer object to store tag in.
     #
     def render_links(tags)
-      [ :canonical, :prev, :next, :author, :publisher ].each do |tag_name|
+      [ :canonical, :prev, :next ].each do |tag_name|
         href = meta_tags.extract(tag_name)
         if href.present?
           @normalized_meta_tags[tag_name] = href

--- a/lib/meta_tags/version.rb
+++ b/lib/meta_tags/version.rb
@@ -1,4 +1,4 @@
 module MetaTags
   # Gem version.
-  VERSION = '2.1.0'
+  VERSION = '2.1.1'
 end

--- a/lib/meta_tags/view_helper.rb
+++ b/lib/meta_tags/view_helper.rb
@@ -160,8 +160,7 @@ module MetaTags
     # @option default [Hash] :alternate ({}) add alternate link tag.
     # @option default [String] :prev (nil) add prev link tag;
     # @option default [String] :next (nil) add next link tag.
-    # @option default [String] :author (nil) add author link tag;
-    # @option default [String] :publisher (nil) add publisher link tag.
+    # @option default [String] :author (nil) add author meta tag;
     # @option default [String, Integer] :refresh (nil) meta refresh tag;
     # @option default [Hash] :open_graph ({}) add Open Graph meta tags.
     # @option default [Hash] :open_search ({}) add Open Search link tag.

--- a/spec/view_helper/links_spec.rb
+++ b/spec/view_helper/links_spec.rb
@@ -63,24 +63,6 @@ describe MetaTags::ViewHelper do
     end
   end
 
-  context 'displaying author link' do
-    it 'should display author link when "set_meta_tags" used' do
-      subject.set_meta_tags(author: 'http://plus.google.com/profile/url')
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).to have_tag('link', with: { href: "http://plus.google.com/profile/url", rel: "author" })
-      end
-    end
-  end
-
-  context 'displaying publisher link' do
-    it 'should display publisher link when "set_meta_tags" used' do
-      subject.set_meta_tags(publisher: 'http://plus.google.com/myprofile_url')
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).to have_tag('link', with: { href: "http://plus.google.com/myprofile_url", rel: "publisher" })
-      end
-    end
-  end
-
   context 'displaying prev url' do
     it 'should not display prev url by default' do
       subject.display_meta_tags(site: 'someSite').tap do |meta|


### PR DESCRIPTION
Removed Google "author" and "publisher" links, as Google deprecated these options (https://support.google.com/webmasters/answer/6083347?hl=en)
