### PR TITLE
Adding MIT license to the gemspec.

### DIFF
--- a/meta-tags.gemspec
+++ b/meta-tags.gemspec
@@ -6,6 +6,7 @@ Gem::Specification.new do |s|
   s.name        = 'meta-tags'
   s.version     = MetaTags::VERSION
   s.platform    = Gem::Platform::RUBY
+  s.license     = "MIT"
   s.authors     = ['Dmytro Shteflyuk']
   s.email       = ['kpumuk@kpumuk.info']
   s.homepage    = 'http://github.com/kpumuk/meta-tags'


### PR DESCRIPTION
I'm working on [VersionEye](https://www.versioneye.com/) and my goal is to build up a license db for RubyGems which is complete. To reduce the manual work I'm doing currently it would be awesome if this gemspec would contain the license information in future. Many Thanks.