### PR TITLE
Fixed double escaping of special characters in title

### DIFF
--- a/lib/meta_tags.rb
+++ b/lib/meta_tags.rb
@@ -1,5 +1,6 @@
 require 'action_controller'
 require 'action_view'
+require 'rails-html-sanitizer'
 
 # MetaTags gem namespace.
 module MetaTags

--- a/lib/meta_tags/text_normalizer.rb
+++ b/lib/meta_tags/text_normalizer.rb
@@ -72,7 +72,7 @@ module MetaTags
     #
     def self.strip_tags(string)
       string ||= ''
-      Rails::Html::WhiteListSanitizer.new.sanitize(string, tags: [])
+      ::Rails::Html::WhiteListSanitizer.new.sanitize(string, tags: [])
     end
 
     # This method returns a html safe string similar to what <tt>Array#join</tt>

--- a/meta-tags.gemspec
+++ b/meta-tags.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.description = %q{Search Engine Optimization (SEO) plugin for Ruby on Rails applications.}
 
   s.add_dependency 'actionpack', '>= 3.0.0'
+  s.add_dependency 'rails-html-sanitizer'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 3.3.0'

--- a/spec/text_normalizer/normalize_title_spec.rb
+++ b/spec/text_normalizer/normalize_title_spec.rb
@@ -16,7 +16,9 @@ describe MetaTags::TextNormalizer, '.normalize_title' do
     end
 
     it 'should escape ampersand in title correctly' do
-      expect(subject.normalize_title(nil, %q(&&&), nil)).to eq("&amp;&amp;&amp;")
+      expect(
+        subject.normalize_title(nil, "&&&", nil)
+      ).to eq("&amp;&amp;&amp;")
     end
   end
 
@@ -41,12 +43,16 @@ describe MetaTags::TextNormalizer, '.normalize_title' do
     it 'should truncate title when limit is reached' do
       site_title = 'a' * 20
       title = 'b' * (MetaTags.config.title_limit + 10)
-      expect(subject.normalize_title(site_title, title, '-')).to eq("#{site_title}-#{'b' * (MetaTags.config.title_limit - 21)}")
+      expect(
+        subject.normalize_title(site_title, title, '-')
+      ).to eq("#{site_title}-#{'b' * (MetaTags.config.title_limit - 21)}")
     end
 
     it 'should escape ampersand in title correctly' do
       site_title = 'a' * 10
-      expect(subject.normalize_title(site_title, "&&&", '-')).to eq("#{site_title}-&amp;&amp;&amp;")
+      expect(
+        subject.normalize_title(site_title, '&&&', '-')
+      ).to eq("#{site_title}-&amp;&amp;&amp;")
     end
   end
 end

--- a/spec/text_normalizer/normalize_title_spec.rb
+++ b/spec/text_normalizer/normalize_title_spec.rb
@@ -14,6 +14,10 @@ describe MetaTags::TextNormalizer, '.normalize_title' do
     it 'should reverse title parts when reverse is true' do
       expect(subject.normalize_title('', %w[title subtitle], '-', true)).to eq('subtitle-title')
     end
+
+    it 'should escape ampersand in title correctly' do
+      expect(subject.normalize_title(nil, %q(&&&), nil)).to eq("&amp;&amp;&amp;")
+    end
   end
 
   context 'when site_title is specified' do
@@ -38,6 +42,11 @@ describe MetaTags::TextNormalizer, '.normalize_title' do
       site_title = 'a' * 20
       title = 'b' * (MetaTags.config.title_limit + 10)
       expect(subject.normalize_title(site_title, title, '-')).to eq("#{site_title}-#{'b' * (MetaTags.config.title_limit - 21)}")
+    end
+
+    it 'should escape ampersand in title correctly' do
+      site_title = 'a' * 10
+      expect(subject.normalize_title(site_title, "&&&", '-')).to eq("#{site_title}-&amp;&amp;&amp;")
     end
   end
 end


### PR DESCRIPTION
This is related to and supersedes https://github.com/kpumuk/meta-tags/pull/85