### PR TITLE
Use Module#prepend instead of alias_method_chain

### DIFF
--- a/lib/meta_tags.rb
+++ b/lib/meta_tags.rb
@@ -34,4 +34,4 @@ require 'meta_tags/text_normalizer'
 require 'meta_tags/view_helper'
 
 ActionView::Base.send :include, MetaTags::ViewHelper
-ActionController::Base.send :include, MetaTags::ControllerHelper
+ActionController::Base.send :prepend, MetaTags::ControllerHelper

--- a/lib/meta_tags/controller_helper.rb
+++ b/lib/meta_tags/controller_helper.rb
@@ -10,22 +10,16 @@ module MetaTags
   # as {ViewHelper#set_meta_tags}.
   #
   module ControllerHelper
-    extend ActiveSupport::Concern
-
-    included do
-      alias_method_chain :render, :meta_tags
-    end
 
     # Processes the <tt>@page_title</tt>, <tt>@page_keywords</tt>, and
     # <tt>@page_description</tt> instance variables and calls +render+.
-    def render_with_meta_tags(*args, &block)
+    def render(*args, &block)
       self.meta_tags[:title]       = @page_title       if @page_title
       self.meta_tags[:keywords]    = @page_keywords    if @page_keywords
       self.meta_tags[:description] = @page_description if @page_description
 
-      render_without_meta_tags(*args, &block)
+      super(*args, &block)
     end
-    protected :render_with_meta_tags
 
     # Set meta tags for the page.
     #


### PR DESCRIPTION
As `alias_method_chain` is being deprecated in Rails 5, it replaced `alias_method_chain` with Module#prepend from Ruby 2+. In addition to #93, this pull request use `prepend` instead of `include` to ensure the `MetaTags::ControllerHelper#render` called before calling `ActionController::Base#render`.

The test is broken since the `render` is no longer blocked by `render_without_meta_tags`.