### PR TITLE
Article tag should use property instead of name

### DIFF
--- a/lib/meta_tags/renderer.rb
+++ b/lib/meta_tags/renderer.rb
@@ -30,6 +30,7 @@ module MetaTags
       render_links(tags)
 
       render_hash(tags, :og, name_key: :property)
+      render_hash(tags, :article, name_key: :property)
       render_hashes(tags)
       render_custom(tags)
 

--- a/spec/view_helper/article_spec.rb
+++ b/spec/view_helper/article_spec.rb
@@ -1,0 +1,34 @@
+require "spec_helper"
+
+describe MetaTags::ViewHelper, "displaying Article meta tags" do
+  subject { ActionView::Base.new }
+
+  it "should display meta tags specified with :article" do
+    subject.set_meta_tags(article: {
+      author:       "https://www.facebook.com/facebook"
+    })
+    subject.display_meta_tags(site: "someSite").tap do |meta|
+      expect(meta).to have_tag("meta", with: { content: "https://www.facebook.com/facebook", property: "article:author" })
+    end
+  end
+
+  it "should use deep merge when displaying open graph meta tags" do
+    subject.set_meta_tags(article: { author: "https://www.facebook.com/facebook" })
+    subject.display_meta_tags(article: { publisher: "https://www.facebook.com/Google/" }).tap do |meta|
+      expect(meta).to have_tag("meta", with: { content: "https://www.facebook.com/facebook", property: "article:author" })
+      expect(meta).to have_tag("meta", with: { content: "https://www.facebook.com/Google/", property: "article:publisher" })
+    end
+  end
+
+  it "should not display meta tags without content" do
+    subject.set_meta_tags(article: {
+      author:       "",
+      publisher:    ""
+    })
+    subject.display_meta_tags(site: "someSite").tap do |meta|
+      expect(meta).to_not have_tag("meta", with: { content: "", property: "article:author" })
+      expect(meta).to_not have_tag("meta", with: { content: "", property: "article:publisher" })
+    end
+  end
+
+end


### PR DESCRIPTION
Facebook debug tool shows that article tag should use property attribute instead of name.