### PR TITLE
Ignore separator length when site_title is empty for the truncation

### DIFF
--- a/lib/meta_tags/text_normalizer.rb
+++ b/lib/meta_tags/text_normalizer.rb
@@ -16,7 +16,13 @@ module MetaTags
       separator = strip_tags(separator)
 
       if MetaTags.config.title_limit
-        limit = MetaTags.config.title_limit - separator.length
+        limit = if site_title.present?
+          MetaTags.config.title_limit - separator.length
+        else
+          # separtor won't be used: ignore its length
+          MetaTags.config.title_limit
+        end
+
         if limit > site_title.length
           title = truncate_array(title, limit - site_title.length, separator)
         else

--- a/spec/text_normalizer/normalize_title_spec.rb
+++ b/spec/text_normalizer/normalize_title_spec.rb
@@ -14,6 +14,11 @@ describe MetaTags::TextNormalizer, '.normalize_title' do
     it 'should reverse title parts when reverse is true' do
       expect(subject.normalize_title('', %w[title subtitle], '-', true)).to eq('subtitle-title')
     end
+
+    it 'should not truncate title when limit is equal to the title length' do
+      title = 'b' * MetaTags.config.title_limit
+      expect(subject.normalize_title('', title, '-')).to eq(title)
+    end
   end
 
   context 'when site_title is specified' do


### PR DESCRIPTION
Otherwise the title could be truncated even if the length didn’t reached
the limit.