### PR TITLE
Truncate site_title instead of title

### DIFF
--- a/lib/meta_tags/configuration.rb
+++ b/lib/meta_tags/configuration.rb
@@ -10,12 +10,16 @@ module MetaTags
     # Keywords separator - a string to join keywords with.
     attr_accessor :keywords_separator
 
+    # Truncate site_title instead of title, default: false
+    attr_accessor :truncate_site_title
+
     # Initializes a new instance of Configuration class.
     def initialize
       @title_limit = 70
       @description_limit = 160
       @keywords_limit = 255
       @keywords_separator = ', '
+      @truncate_site_title = false
     end
   end
 end

--- a/lib/meta_tags/text_normalizer.rb
+++ b/lib/meta_tags/text_normalizer.rb
@@ -23,12 +23,25 @@ module MetaTags
           MetaTags.config.title_limit
         end
 
-        if limit > site_title.length
-          title = truncate_array(title, limit - site_title.length, separator)
-        else
-          site_title = truncate(site_title, limit)
-          # Site title is too long, we have to skip page title
-          title = []
+        title_length = safe_join(title, separator).length
+        full_title_length = title_length + site_title.length 
+        full_title_length -= separator.length if site_title.present?
+
+        if title_length > limit
+          title = truncate_array(title, limit)
+          site_title = []
+        elsif full_title_length > limit
+          if MetaTags.config.truncate_site_title
+            site_title = truncate(site_title, limit - title_length)
+          else
+            if limit > site_title.length
+              title = truncate_array(title, limit - site_title.length, separator)
+            else
+              site_title = truncate(site_title, limit)
+              # Site title is too long, we have to skip page title
+              title = []
+            end
+          end 
         end
       end
 


### PR DESCRIPTION
You can set the priority for truncation

**Example**

```
site_title = "Awesome site name"
title = "My site"
```

**Without truncate_site_title**

```
# truncate_site_title default is false
# "site title" have more priority then "title"
MetaTags.configure do |c|
  c.title_limit = 15
end
Output: <title>Awesome site</title>
```

**With truncate_site_title = true**

```
# "title" have more priority then "site title"
MetaTags.configure do |c|
  c.title_limit = 15
  c.truncate_site_title = true
end
Output: <title>My site | Aweso</title>
```
