### PR TITLE
use property as key name for place attributes

### DIFF
--- a/lib/meta_tags/renderer.rb
+++ b/lib/meta_tags/renderer.rb
@@ -33,6 +33,7 @@ module MetaTags
       render_hash(tags, :al, name_key: :property)
       render_hash(tags, :fb, name_key: :property)
       render_hash(tags, :article, name_key: :property)
+      render_hash(tags, :place, name_key: :property)
       render_hashes(tags)
       render_custom(tags)
 


### PR DESCRIPTION
Use the `property` key name for `place` attributes per facebook requirements.

https://developers.facebook.com/docs/reference/opengraph/object-type/place/
