### PR TITLE
Ability to create AMP links 

### DIFF
--- a/lib/meta_tags/renderer.rb
+++ b/lib/meta_tags/renderer.rb
@@ -151,7 +151,7 @@ module MetaTags
     # @param [Array<Tag>] tags a buffer object to store tag in.
     #
     def render_links(tags)
-      [ :canonical, :prev, :next, :author, :publisher, :image_src ].each do |tag_name|
+      [ :amphtml, :canonical, :prev, :next, :author, :publisher, :image_src ].each do |tag_name|
         href = meta_tags.extract(tag_name)
         if href.present?
           @normalized_meta_tags[tag_name] = href

--- a/spec/view_helper/links_spec.rb
+++ b/spec/view_helper/links_spec.rb
@@ -143,4 +143,25 @@ describe MetaTags::ViewHelper do
       end
     end
   end
+
+  context 'displaying amphtml url' do
+    it 'should not display amphtml url by default' do
+      subject.display_meta_tags(site: 'someSite').tap do |meta|
+        expect(meta).to_not have_tag('link', with: { href: "http://example.com/base/url.amp", rel: "amphtml" })
+      end
+    end
+
+    it 'should display amphtml url when "set_meta_tags" used' do
+      subject.set_meta_tags(amphtml: 'http://example.com/base/url.amp')
+      subject.display_meta_tags(site: 'someSite').tap do |meta|
+        expect(meta).to have_tag('link', with: { href: "http://example.com/base/url.amp", rel: "amphtml" })
+      end
+    end
+
+    it 'should display default amphtml url' do
+      subject.display_meta_tags(site: 'someSite', amphtml: 'http://example.com/base/url.amp').tap do |meta|
+        expect(meta).to have_tag('link', with: { href: "http://example.com/base/url.amp", rel: "amphtml" })
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://www.ampproject.org/docs/get_started/create/prepare_for_discovery

Ability to create AMP links that point from a none AMP page to the equivalent AMP webpage.