### PR TITLE
Allow to specify custom tags that use `property` attribute instead of `name`

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,11 @@ preferences. In order to do that, you can create an initializer
 
 ```ruby
 MetaTags.configure do |c|
-  c.title_limit        = 70
-  c.description_limit  = 160
-  c.keywords_limit     = 255
-  c.keywords_separator = ', '
+  c.title_limit          = 70
+  c.description_limit    = 160
+  c.keywords_limit       = 255
+  c.keywords_separator   = ', '
+  c.custom_property_tags = ['x-hearthstone:deck']
 end
 ```
 

--- a/lib/meta_tags/configuration.rb
+++ b/lib/meta_tags/configuration.rb
@@ -9,6 +9,9 @@ module MetaTags
     attr_accessor :keywords_limit
     # Keywords separator - a string to join keywords with.
     attr_accessor :keywords_separator
+    # Custom meta tags that should use `property` attribute instead of `name`
+    # - an array of strings or symbols representing their names or name-prefixes.
+    attr_accessor :custom_property_tags
 
     # Initializes a new instance of Configuration class.
     def initialize
@@ -16,6 +19,7 @@ module MetaTags
       @description_limit = 160
       @keywords_limit = 255
       @keywords_separator = ', '
+      @custom_property_tags = []
     end
   end
 end

--- a/lib/meta_tags/renderer.rb
+++ b/lib/meta_tags/renderer.rb
@@ -192,7 +192,7 @@ module MetaTags
     def render_custom(tags)
       meta_tags.meta_tags.each do |name, data|
         Array(data).each do |val|
-          tags << Tag.new(:meta, name: name, content: val)
+          tags << Tag.new(:meta, configured_name_key(name) => name, content: val)
         end
         meta_tags.extract(name)
       end
@@ -249,9 +249,19 @@ module MetaTags
     # top-level meta tag.
     #
     def render_tag(tags, name, value, options = {})
-      name_key = options.fetch(:name_key, :name)
+      name_key = options.fetch(:name_key, configured_name_key(name))
       value_key = options.fetch(:value_key, :content)
       tags << Tag.new(:meta, name_key => name.to_s, value_key => value) unless value.blank?
+    end
+
+
+    private
+
+    def configured_name_key(name)
+      MetaTags.config.custom_property_tags.each do |tag_name|
+        return 'property' if name.match(Regexp.new("\^#{tag_name}"))
+      end
+      'name'
     end
   end
 end

--- a/spec/view_helper/custom_spec.rb
+++ b/spec/view_helper/custom_spec.rb
@@ -36,32 +36,58 @@ describe MetaTags::ViewHelper do
     end
 
     it 'should display meta tags with hashes and arrays' do
-      subject.set_meta_tags(foo: {
-        bar: "lorem",
-        baz: {
-          qux: ["lorem", "ipsum"]
-        },
-        quux: [
-          {
-            corge:  "lorem",
-            grault: "ipsum"
-          },
-          {
-            corge:  "dolor",
-            grault: "sit"
-          }
-        ]
-      })
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).to have_tag('meta', with: { content: "lorem", name: "foo:bar" })
-        expect(meta).to have_tag('meta', with: { content: "lorem", name: "foo:baz:qux" })
-        expect(meta).to have_tag('meta', with: { content: "ipsum", name: "foo:baz:qux" })
-        expect(meta).to have_tag('meta', with: { content: "lorem", name: "foo:quux:corge" })
-        expect(meta).to have_tag('meta', with: { content: "ipsum", name: "foo:quux:grault" })
-        expect(meta).to have_tag('meta', with: { content: "dolor", name: "foo:quux:corge" })
-        expect(meta).to have_tag('meta', with: { content: "sit", name: "foo:quux:grault" })
-        expect(meta).to_not have_tag('meta', with: { name: "foo:quux" })
+      test_hashes_and_arrays
+    end
+
+    it 'should use `property` attribute instead of `name` for custom tags listed under `custom_property_tags` in config' do
+      MetaTags.configure do |config|
+        config.custom_property_tags = [:testing1, 'testing2']
       end
+
+      subject.display_meta_tags('testing1': 'test').tap do |meta|
+        expect(meta).to have_tag('meta', with: { content: "test", property: "testing1" })
+      end
+
+      subject.display_meta_tags('testing2:nested': 'nested test').tap do |meta|
+        expect(meta).to have_tag('meta', with: { content: "nested test", property: "testing2:nested" })
+      end
+    end
+
+    it 'should display `custom_property_tags` in hashes and arrays properly' do
+      MetaTags.configure do |config|
+        config.custom_property_tags = [:foo]
+      end
+
+      test_hashes_and_arrays(name_key: :property)
+    end
+  end
+
+  def test_hashes_and_arrays(name_key: :name)
+    subject.set_meta_tags(foo: {
+      bar: "lorem",
+      baz: {
+        qux: ["lorem", "ipsum"]
+      },
+      quux: [
+        {
+          corge:  "lorem",
+          grault: "ipsum"
+        },
+        {
+          corge:  "dolor",
+          grault: "sit"
+        }
+      ]
+    })
+    subject.display_meta_tags(site: 'someSite').tap do |meta|
+      expect(meta).to have_tag('meta', with: { content: "lorem", name_key => "foo:bar" })
+      expect(meta).to have_tag('meta', with: { content: "lorem", name_key => "foo:baz:qux" })
+      expect(meta).to have_tag('meta', with: { content: "ipsum", name_key => "foo:baz:qux" })
+      expect(meta).to have_tag('meta', with: { content: "lorem", name_key => "foo:quux:corge" })
+      expect(meta).to have_tag('meta', with: { content: "ipsum", name_key => "foo:quux:grault" })
+      expect(meta).to have_tag('meta', with: { content: "dolor", name_key => "foo:quux:corge" })
+      expect(meta).to have_tag('meta', with: { content: "sit", name_key => "foo:quux:grault" })
+      expect(meta).to_not have_tag('meta', with: { name: "foo:quux" })
     end
   end
 end


### PR DESCRIPTION
Solves https://github.com/kpumuk/meta-tags/issues/134