### PR TITLE
Allow MetaTagsCollection#update to recieve object

### DIFF
--- a/lib/meta_tags/meta_tags_collection.rb
+++ b/lib/meta_tags/meta_tags_collection.rb
@@ -36,11 +36,8 @@ module MetaTags
     # @return [Hash] result of the merge.
     #
     def update(object = {})
-      if object.respond_to?(:to_meta_tags)
-        @meta_tags.deep_merge! normalize_open_graph(object.to_meta_tags)
-      else
-        @meta_tags.deep_merge! normalize_open_graph(object)
-      end
+      meta_tags = object.respond_to?(:to_meta_tags) ? object.to_meta_tags : object
+      @meta_tags.deep_merge! normalize_open_graph(meta_tags)
     end
 
     # Temporary merges defaults with current meta tags list and yields the block.

--- a/lib/meta_tags/meta_tags_collection.rb
+++ b/lib/meta_tags/meta_tags_collection.rb
@@ -31,11 +31,16 @@ module MetaTags
 
     # Recursively merges a Hash of meta tag attributes into current list.
     #
-    # @param [Hash] meta_tags meta tags Hash to merge into current list.
+    # @param [Hash, #to_meta_tags] object Hash of meta tags (or object responding
+    #   to #to_meta_tags and returning a hash) to merge into the current list.
     # @return [Hash] result of the merge.
     #
-    def update(meta_tags = {})
-      @meta_tags.deep_merge! normalize_open_graph(meta_tags)
+    def update(object = {})
+      if object.respond_to?(:to_meta_tags)
+        @meta_tags.deep_merge! normalize_open_graph(object.to_meta_tags)
+      else
+        @meta_tags.deep_merge! normalize_open_graph(object)
+      end
     end
 
     # Temporary merges defaults with current meta tags list and yields the block.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -63,12 +63,27 @@ RSpec.configure do |config|
 end
 
 shared_examples_for '.set_meta_tags' do
-  it 'should update meta tags' do
-    subject.set_meta_tags(title: 'hello')
-    expect(subject.meta_tags[:title]).to eq('hello')
+  context 'parameter is a Hash' do
+    it 'should update meta tags' do
+      subject.set_meta_tags(title: 'hello')
+      expect(subject.meta_tags[:title]).to eq('hello')
 
-    subject.set_meta_tags(title: 'world')
-    expect(subject.meta_tags[:title]).to eq('world')
+      subject.set_meta_tags(title: 'world')
+      expect(subject.meta_tags[:title]).to eq('world')
+    end
+  end
+
+  context 'parameter is an Object responding to #to_meta_tags' do
+    it 'should update meta tags' do
+      object1 = double(to_meta_tags: { title: 'hello' })
+      object2 = double(to_meta_tags: { title: 'world' })
+
+      subject.set_meta_tags(object1)
+      expect(subject.meta_tags[:title]).to eq('hello')
+
+      subject.set_meta_tags(object2)
+      expect(subject.meta_tags[:title]).to eq('world')
+    end
   end
 
   it 'should use deep merge when updating meta tags' do


### PR DESCRIPTION
- If object responds to #to_meta_tags, call it. Otherwise, assume it's a
  Hash of meta tags and proceed as usual.
- Allows set_meta_tags to receive an object that responds to
  to_meta_tags and just work

Closes #168 