### PR TITLE
[Text normalizer] Description could an object, not a string

### DIFF
--- a/lib/meta_tags/text_normalizer.rb
+++ b/lib/meta_tags/text_normalizer.rb
@@ -38,6 +38,10 @@ module MetaTags
     # to 200 characters.
     #
     def normalize_description(description)
+      # description could be another object not a string, but since it probably
+      # serves the same purpose we could just as it to convert itself to str
+      # and continue from there
+      description = description.to_str if description
       return '' if description.blank?
       description = cleanup_string(description)
       truncate(description, MetaTags.config.description_limit)


### PR DESCRIPTION
I have another object from another gem that is called @page_description and it is not a string. It is an active record. So could we call description.to_str and thus allow other objects to be passed. 