### PR TITLE
[Text normalizer] Title, description, and keywords can be String-like objects

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -73,6 +73,10 @@ Metrics/MethodLength:
   Exclude:
     - 'db/migrate/*'
 
+Metrics/ModuleLength:
+  Max: 250
+  CountComments: false
+
 Rails/UnknownEnv:
   Environments:
     - development

--- a/lib/meta_tags/text_normalizer.rb
+++ b/lib/meta_tags/text_normalizer.rb
@@ -41,6 +41,10 @@ module MetaTags
     # to 200 characters.
     #
     def normalize_description(description)
+      # description could be another object not a string, but since it probably
+      # serves the same purpose we could just as it to convert itself to str
+      # and continue from there
+      description = description.to_str if description
       return '' if description.blank?
 
       description = cleanup_string(description)

--- a/spec/view_helper/description_spec.rb
+++ b/spec/view_helper/description_spec.rb
@@ -66,4 +66,22 @@ describe MetaTags::ViewHelper, 'displaying description' do
       expect(meta).to have_tag('meta', with: { content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam dolor lorem, lobortis quis faucibus id, tristique at lorem. Nullam sit amet mollis libero. Morbi ut sem malesuada massa faucibus vestibulum non sed quam. Duis quis consectetur lacus. Donec vitae nunc risus. Sed placerat semper elit, sit", name: "description" })
     end
   end
+
+  it 'should treat nil as an empty string' do
+    subject.display_meta_tags(description: nil).tap do |meta|
+      expect(meta).to_not have_tag('meta', with: { name: "description" })
+    end
+  end
+
+  it 'should allow objects that respond to #to_str' do
+    description = double(to_str: 'some description')
+    subject.display_meta_tags(description: description).tap do |meta|
+      expect(meta).to have_tag('meta', with: { content: "some description", name: "description" })
+    end
+  end
+
+  it 'should fail when title is not a String-like object' do
+    expect { subject.display_meta_tags(description: 5) }.to \
+      raise_error ArgumentError, 'Expected a string or an object that implements #to_str'
+  end
 end

--- a/spec/view_helper/title_spec.rb
+++ b/spec/view_helper/title_spec.rb
@@ -117,11 +117,14 @@ describe MetaTags::ViewHelper do
       subject.display_meta_tags(site: 'someSite', separator: '&amp;').tap do |meta|
         expect(meta).to eq('<title>someSite &amp;amp; someTitle</title>')
       end
+      subject.display_meta_tags(site: 'someSite', separator: '&').tap do |meta|
+        expect(meta).to eq('<title>someSite &amp; someTitle</title>')
+      end
       subject.display_meta_tags(site: 'someSite', separator: '&amp;'.html_safe).tap do |meta|
         expect(meta).to eq('<title>someSite &amp; someTitle</title>')
       end
-      subject.display_meta_tags(site: 'someSite: ', separator: false).tap do |meta|
-        expect(meta).to eq('<title>someSite: someTitle</title>')
+      subject.display_meta_tags(site: 'someSite:', separator: false).tap do |meta|
+        expect(meta).to eq('<title>someSite:someTitle</title>')
       end
     end
     # rubocop:enable Rails/OutputSafety
@@ -168,6 +171,24 @@ describe MetaTags::ViewHelper do
       subject.display_meta_tags(site: 'someSite', title: ['someTitle', 'anotherTitle'], lowercase: true).tap do |meta|
         expect(meta).to eq('<title>someSite | sometitle | anothertitle</title>')
       end
+    end
+
+    it 'should treat nil as an empty string' do
+      subject.display_meta_tags(title: nil).tap do |meta|
+        expect(meta).to_not have_tag('title')
+      end
+    end
+
+    it 'should allow objects that respond to #to_str' do
+      title = double(to_str: 'someTitle')
+      subject.display_meta_tags(site: 'someSite', title: title).tap do |meta|
+        expect(meta).to eq('<title>someSite | someTitle</title>')
+      end
+    end
+
+    it 'should fail when title is not a String-like object' do
+      expect { subject.display_meta_tags(site: 'someSite', title: 5) }.to \
+        raise_error ArgumentError, 'Expected a string or an object that implements #to_str'
     end
 
     it 'should build title in reverse order if :reverse' do


### PR DESCRIPTION
### Description

This PR is an extension of https://github.com/kpumuk/meta-tags/pull/175, adding support for `#to_str` to titles and keywords.

Closes #174