### PR TITLE
Fix typo in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Features:
   - Added a configuration option `minify_output` to remove new line characters between meta tags ([182](https://github.com/kpumuk/meta-tags/pull/182))
-  – Title, description, and keywords can be an object responding to `#to_str` ([183](https://github.com/kpumuk/meta-tags/pull/183))
+  - Title, description, and keywords can be an object responding to `#to_str` ([183](https://github.com/kpumuk/meta-tags/pull/183))
 
 Bugfixes:
   - Truncate title before escaping HTML characters ([180](https://github.com/kpumuk/meta-tags/pull/180))


### PR DESCRIPTION
https://github.com/kpumuk/meta-tags/blob/master/CHANGELOG.md#2110-november-16-2018-

# Before
![image](https://user-images.githubusercontent.com/608755/48682288-d13b5000-ebea-11e8-95a3-860432be04d7.png)

# After
![image](https://user-images.githubusercontent.com/608755/48682297-e7e1a700-ebea-11e8-99b7-a6c38adcf346.png)
