### PR TITLE
Added support for "itemprop" in custom hashes

### DIFF
--- a/lib/meta_tags/renderer.rb
+++ b/lib/meta_tags/renderer.rb
@@ -251,9 +251,9 @@ module MetaTags
     # @param [String, Symbol] value text content or a symbol reference to
     # top-level meta tag.
     #
-    def render_tag(tags, name, value, name_key: nil, value_key: :content, itemprop: nil)
+    def render_tag(tags, name, value, itemprop: nil)
       name_key ||= configured_name_key(name)
-      tags << Tag.new(:meta, name_key => name.to_s, value_key => value, itemprop: itemprop) if value.present?
+      tags << Tag.new(:meta, name_key => name.to_s, content: value, itemprop: itemprop) if value.present?
     end
 
     # Returns meta tag property name for a give meta tag based on the

--- a/lib/meta_tags/renderer.rb
+++ b/lib/meta_tags/renderer.rb
@@ -201,16 +201,17 @@ module MetaTags
     # @param [Hash, Array, String, Symbol] content text content or a symbol reference to
     # top-level meta tag.
     #
-    def process_tree(tags, property, content, **opts)
+    def process_tree(tags, property, content, itemprop: nil, **opts)
       method = case content
                when Hash
                  :process_hash
                when Array
                  :process_array
                else
+                 iprop = itemprop
                  :render_tag
                end
-      __send__(method, tags, property, content, **opts)
+      __send__(method, tags, property, content, itemprop: iprop, **opts)
     end
 
     # Recursive method to process a hash with meta tags
@@ -220,10 +221,16 @@ module MetaTags
     # @param [Hash] content nested meta tag attributes.
     #
     def process_hash(tags, property, content, **opts)
+      itemprop = content.delete(:itemprop)
       content.each do |key, value|
-        key = key.to_s == '_' ? property : "#{property}:#{key}"
+        if key.to_s == '_'
+          iprop = itemprop
+          key = property
+        else
+          key = "#{property}:#{key}"
+        end
         value = normalized_meta_tags[value] if value.kind_of?(Symbol)
-        process_tree(tags, key, value, **opts)
+        process_tree(tags, key, value, **opts.merge(itemprop: iprop))
       end
     end
 
@@ -244,9 +251,9 @@ module MetaTags
     # @param [String, Symbol] value text content or a symbol reference to
     # top-level meta tag.
     #
-    def render_tag(tags, name, value, name_key: nil, value_key: :content)
+    def render_tag(tags, name, value, name_key: nil, value_key: :content, itemprop: nil)
       name_key ||= configured_name_key(name)
-      tags << Tag.new(:meta, name_key => name.to_s, value_key => value) if value.present?
+      tags << Tag.new(:meta, name_key => name.to_s, value_key => value, itemprop: itemprop) if value.present?
     end
 
     # Returns meta tag property name for a give meta tag based on the

--- a/spec/view_helper/custom_spec.rb
+++ b/spec/view_helper/custom_spec.rb
@@ -41,7 +41,7 @@ describe MetaTags::ViewHelper do
       subject.set_meta_tags(
         og: {
           image: {
-               _:     'image.png',
+            _:        'image.png',
             type:     'image/jpeg',
             width:    200,
             height:   {

--- a/spec/view_helper/custom_spec.rb
+++ b/spec/view_helper/custom_spec.rb
@@ -37,6 +37,32 @@ describe MetaTags::ViewHelper do
       end
     end
 
+    it 'allows to specify itemprop' do
+      subject.set_meta_tags(
+        og: {
+          image: {
+               _:     'image.png',
+            type:     'image/jpeg',
+            width:    200,
+            height:   {
+              _:        200,
+              itemprop: 'custom',
+            },
+            itemprop: 'image',
+          },
+        },
+      )
+
+      meta = subject.display_meta_tags
+      aggregate_failures 'meta tags' do
+        expect(meta).to have_tag('meta', with: { property: "og:image", content: "image.png", itemprop: "image" })
+        expect(meta).to have_tag('meta', with: { property: "og:image:type", content: "image/jpeg" }, without: { itemprop: "image" })
+        expect(meta).to have_tag('meta', with: { property: "og:image:width", content: "200" }, without: { itemprop: "image" })
+        expect(meta).to have_tag('meta', with: { property: "og:image:height", content: "200", itemprop: "custom" })
+        expect(meta).not_to have_tag('meta', with: { property: "og:image:itemprop" })
+      end
+    end
+
     it 'displays meta tags with hashes and arrays' do
       test_hashes_and_arrays
     end


### PR DESCRIPTION
I am not sure how I feel about this change yet. Basically, it starts treating `itemprop` attribute in a special way, applying `itemprop` attribute to `_` tag:

```ruby
display_meta_tags(
  og: {
    image: {
       _:       'image.png',
      itemprop: 'image',
      type:     'image/jpeg',
      width:    200,
      height:   {
        _:        200,
        itemprop: 'custom',
      },
    },
  },
)
```

Closes #198 