### PR TITLE
Restrict minimal Ruby version to 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Bugfixes:
 Features:
   - Indexing directives (`noindex`, `nofollow`, etc. now support an array of robot names as a value).
   - Added support for `link[rel='manifest']` ([199](https://github.com/kpumuk/meta-tags/pull/199))
+  - Minimal required Ruby version is now 2.4.0
 
 Bugfixes:
   - When `noindex` uses "robots" as a value, `nofollow` ignores a custom robot name, and switches to "robots" as well

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Search Engine Optimization (SEO) plugin for Ruby on Rails applications.
 MetaTags master branch fully supports Ruby on Rails 4.2+, and is tested against all
 major Rails releases up to 6.0.beta2.
 
-Ruby versions older than 2.2.0 are no longer officially supported.
+Ruby versions older than 2.4.0 are no longer officially supported.
 
-_Please note_ that we are no longer support Ruby versions older than 2.2.0 and
+_Please note_ that we are no longer support Ruby versions older than 2.4.0 and
 Ruby on Rails older than 4.2, because they [reached their End of Life](https://github.com/kpumuk/meta-tags/pull/143).
 
 ## Installation

--- a/meta-tags.gemspec
+++ b/meta-tags.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "http://github.com/kpumuk/meta-tags"
   spec.license       = "MIT"
   spec.platform      = Gem::Platform::RUBY
+  spec.required_ruby_version = '>= 2.4.0'
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(\.|(bin|test|spec|features)/)}) }
   spec.bindir        = "exe"


### PR DESCRIPTION
Thank you for your great work, @kpumuk !

In version 2.12 of the gem the `transform_values` method, called on a hash, has been introduced - https://github.com/kpumuk/meta-tags/pull/201/files#diff-a95b6e1bb981e380eaa6ee3996b217afR158

This method has appeared in Ruby 2.4.0, thus this PR.