### PR TITLE
feat: skip canonical on noindex pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ group :test do
   # Apply RSpec rubocop cops
   gem 'rubocop-rspec', require: false
   # We use this gem on CI to calculate code coverage.
-  gem 'simplecov'
+  gem 'simplecov', '< 0.18'
   # Format RSpec output for CircleCI
   gem 'rspec_junit_formatter'
 end

--- a/README.md
+++ b/README.md
@@ -409,6 +409,9 @@ Canonical link element tells a search engine what is the canonical or main URL
 for a content which have multiple URLs. The search engine will always return
 that URL, and link popularity and authority will be applied to that URL.
 
+Note: If you like follow a hint of John Mueller that you shouldn't mix canonical with noindex, then you can
+set `MetaTags.config.skip_canonical_links_on_noindex = true` and we'll handle it for you.
+
 ```ruby
 set_meta_tags canonical: "http://yoursite.com/canonical/url"
 # <link rel="canonical" href="http://yoursite.com/canonical/url">

--- a/lib/meta_tags/configuration.rb
+++ b/lib/meta_tags/configuration.rb
@@ -33,6 +33,12 @@ module MetaTags
     # - an array of strings or symbols representing their names or name-prefixes.
     attr_reader :property_tags
 
+    # Configure whenever Meta-Tags should skip canonicals on pages with noindex: true
+    # "shouldn't mix noindex & rel=canonical comes from: they're very contradictory pieces of information for us."
+    # - John Mueller (Webmaster Trends Analyst at Google)
+    # https://www.reddit.com/r/TechSEO/comments/8yahdr/2_questions_about_the_canonical_tag/e2dey9i/
+    attr_accessor :skip_canonical_links_on_noindex
+
     # Initializes a new instance of Configuration class.
     def initialize
       reset_defaults!
@@ -77,6 +83,7 @@ module MetaTags
       @property_tags = default_property_tags.dup
       @open_meta_tags = true
       @minify_output = false
+      @skip_canonical_links_on_noindex = false
     end
   end
 end

--- a/lib/meta_tags/renderer.rb
+++ b/lib/meta_tags/renderer.rb
@@ -26,6 +26,7 @@ module MetaTags
       render_with_normalization(tags, :description)
       render_with_normalization(tags, :keywords)
       render_refresh(tags)
+      render_canonical_link(tags)
       render_noindex(tags)
       render_alternate(tags)
       render_open_search(tags)
@@ -150,13 +151,26 @@ module MetaTags
     # @param [Array<Tag>] tags a buffer object to store tag in.
     #
     def render_links(tags)
-      [ :amphtml, :canonical, :prev, :next, :image_src, :manifest ].each do |tag_name|
+      [ :amphtml, :prev, :next, :image_src, :manifest ].each do |tag_name|
         href = meta_tags.extract(tag_name)
         if href.present?
           @normalized_meta_tags[tag_name] = href
           tags << Tag.new(:link, rel: tag_name, href: href)
         end
       end
+    end
+
+    # Renders canonical link
+    #
+    # @param [Array<Tag>] tags a buffer object to store tag in.
+    #
+    def render_canonical_link(tags)
+      href = meta_tags.extract(:canonical) # extract, so its not used anywhere else
+      return if MetaTags.config.skip_canonical_links_on_noindex && meta_tags[:noindex]
+      return if href.blank?
+
+      @normalized_meta_tags[:canonical] = href
+      tags << Tag.new(:link, rel: :canonical, href: href)
     end
 
     # Renders complex hash objects.

--- a/spec/view_helper/links_spec.rb
+++ b/spec/view_helper/links_spec.rb
@@ -22,6 +22,37 @@ describe MetaTags::ViewHelper do
         expect(meta).to have_tag('link', with: { href: "http://example.com/base/url", rel: "canonical" })
       end
     end
+
+    it 'does display canonical url when page is marked as noindex per default' do
+      subject.set_meta_tags(canonical: 'http://example.com/base/url', noindex: true)
+      subject.display_meta_tags(site: 'someSite').tap do |meta|
+        expect(meta).to have_tag('link', with: { href: "http://example.com/base/url", rel: "canonical" })
+      end
+    end
+
+    describe 'with config.skip_canonical_links_on_noindex is set' do
+      around do |example|
+        default = MetaTags.config.skip_canonical_links_on_noindex
+        MetaTags.config.skip_canonical_links_on_noindex = true
+        example.run
+        MetaTags.config.skip_canonical_links_on_noindex = default
+      end
+
+      it 'does display canonical url when page is marked as index' do
+        subject.set_meta_tags(canonical: 'http://example.com/base/url', index: true)
+        subject.display_meta_tags(site: 'someSite').tap do |meta|
+          expect(meta).to have_tag('link', with: { href: "http://example.com/base/url", rel: "canonical" })
+        end
+      end
+
+      it 'does not display canonical url when page is marked as noindex' do
+        subject.set_meta_tags(canonical: 'http://example.com/base/url', noindex: true)
+        subject.display_meta_tags(site: 'someSite').tap do |meta|
+          expect(meta).not_to have_tag('link', with: { href: "http://example.com/base/url", rel: "canonical" })
+          expect(meta).not_to have_tag('meta', with: { content: "http://example.com/base/url", name: "canonical" })
+        end
+      end
+    end
   end
 
   describe 'displaying alternate url' do


### PR DESCRIPTION
Based on a Comment of John Mueller (Webmaster Trends Analyst at Google) on [Reddit](https://www.reddit.com/r/TechSEO/comments/8yahdr/2_questions_about_the_canonical_tag/e2dey9i/)
> This is also where the guide that you shouldn't mix noindex & rel=canonical comes from: they're very contradictory pieces of information for us. We'll generally pick the rel=canonical and use that over the noindex, but any time you rely on interpretation by a computer script, you reduce the weight of your input

This merge request therefor introduces a configuration for MetaTags that allows us to choose if we want to skip the canonical url on noindex pages, as it could "override" the noindex for that page.