### PR TITLE
chore: limit simplecov to version below 0.18

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ group :test do
   # Apply RSpec rubocop cops
   gem 'rubocop-rspec', require: false
   # We use this gem on CI to calculate code coverage.
-  gem 'simplecov'
+  gem 'simplecov', '< 0.18'
   # Format RSpec output for CircleCI
   gem 'rspec_junit_formatter'
 end


### PR DESCRIPTION
related to https://github.com/codeclimate/test-reporter/issues/418

simplecov versions below 0.18 shouldn't have that problem. 