### PR TITLE
Supports custom robots tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Use these options to customize the title format:
 | `:og`          | add Open Graph tags (Hash)                                                                                           |
 | `:twitter`     | add Twitter tags (Hash)                                                                                              |
 | `:refresh`     | refresh interval and optionally url to redirect to                                                                   |
+| `:robots`      | add custom robots tags (Hash)                                                                                        |
 
 And here are a few examples to give you ideas.
 
@@ -718,6 +719,23 @@ set_meta_tags al: {
 Further reading:
 
 - [App Links Documentation](https://developers.facebook.com/docs/applinks)
+
+### Robots
+
+Besides using noindex, there's still other custom robots met tags options to instruct search engine to serve crawled site content in specific ways.
+
+```ruby
+set_meta_tags robots: {
+  "max-snippet": -1,
+  "max-video-preview": -1
+}
+
+#　<meta name="robots" content="max-snippet:-1, max-video-preview:-1">
+```
+
+Further reading:
+
+* [Robots meta tag, data-nosnippet, and X-Robots-Tag specifications](https://developers.google.com/search/reference/robots_meta_tag)
 
 ### Custom meta tags
 

--- a/lib/meta_tags/meta_tags_collection.rb
+++ b/lib/meta_tags/meta_tags_collection.rb
@@ -155,6 +155,11 @@ module MetaTags
         calculate_robots_attributes(result, attributes)
       end
 
+      robots = extract(:robots).presence
+      if robots
+        result['robots'].concat robots.map { |k, v| "#{k}:#{v}" }
+      end
+
       result.transform_values { |v| v.join(', ') }
     end
 

--- a/lib/meta_tags/view_helper.rb
+++ b/lib/meta_tags/view_helper.rb
@@ -169,6 +169,7 @@ module MetaTags
     # @option default [String, Integer] :refresh (nil) meta refresh tag;
     # @option default [Hash] :open_graph ({}) add Open Graph meta tags.
     # @option default [Hash] :open_search ({}) add Open Search link tag.
+    # @option default [Hash] :robots ({}) add robots meta tags.
     # @return [String] HTML meta tags to render in HEAD section of the
     #   HTML document.
     #

--- a/spec/view_helper/robots_spec.rb
+++ b/spec/view_helper/robots_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe MetaTags::ViewHelper, "displaying robots meta tags" do
+  it "displays meta tags specified with :robots" do
+    subject.display_meta_tags(robots: { "max-snippet": -1 }).tap do |meta|
+      expect(meta).to have_tag("meta", with: { content: "max-snippet:-1", name: "robots" })
+    end
+  end
+
+  it "displays multiple custom robots tags in an array" do
+    subject.display_meta_tags(robots: { "max-snippet": -1, "max-video-preview": -1 }).tap do |meta|
+      expect(meta).to have_tag("meta", with: { content: "max-snippet:-1, max-video-preview:-1", name: "robots" })
+    end
+  end
+
+  it "displays custom robots tags alng with noindex" do
+    subject.noindex(true)
+    subject.display_meta_tags(robots: { "max-snippet": -1, "max-video-preview": -1 }).tap do |meta|
+      expect(meta).to have_tag("meta", with: { content: "noindex, max-snippet:-1, max-video-preview:-1", name: "robots" })
+    end
+  end
+end


### PR DESCRIPTION
As titled, this PR make meta-tags support things like:
```html
<meta name="robots" content="max-snippet:-1, max-video-preview:-1">
```