### PR TITLE
Getting ready for Rails 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+
+## 2.16.0 (September 24, 2021) [☰](https://github.com/kpumuk/meta-tags/compare/v2.15.0...v2.16.0)
+
+Changes:
+
+- Removed maximum dependency specified in gemspec (Getting Ready for Rails 7)
+
 ## 2.15.0 (August 2, 2021) [☰](https://github.com/kpumuk/meta-tags/compare/v2.14.0...v2.15.0)
 
 Changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 Changes:
 
-- Removed maximum dependency specified in gemspec (Getting Ready for Rails 7)
+- Updated maximum dependency specified in gemspec (Getting Ready for Rails 7)
 
 ## 2.15.0 (August 2, 2021) [☰](https://github.com/kpumuk/meta-tags/compare/v2.14.0...v2.15.0)
 

--- a/lib/meta_tags/version.rb
+++ b/lib/meta_tags/version.rb
@@ -2,6 +2,6 @@
 
 module MetaTags
   # Gem version.
-  VERSION = '2.15.0'
+  VERSION = '2.16.0'
   public_constant :VERSION
 end

--- a/meta-tags.gemspec
+++ b/meta-tags.gemspec
@@ -22,9 +22,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "actionpack", ">= 3.2.0", "< 6.2"
+  spec.add_dependency "actionpack", ">= 3.2.0", "< 7.1"
 
-  spec.add_development_dependency "railties", ">= 3.2.0", "< 6.2"
+  spec.add_development_dependency "railties", ">= 3.2.0", "< 7.1"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.10.0"
   spec.add_development_dependency "rspec-html-matchers", "~> 0.9.1"


### PR DESCRIPTION
Removed max version validation from dependency.
Getting ready for Rails 7.

Note:-
Using 7.1 max version limit because Alpha release considered more than 7.0 by bundler.