### PR TITLE
Support additional mirrored values

### DIFF
--- a/lib/meta_tags/renderer.rb
+++ b/lib/meta_tags/renderer.rb
@@ -245,7 +245,7 @@ module MetaTags
         end
 
         normalized_value = if value.kind_of?(Symbol)
-                             normalized_meta_tags[value]
+                             normalized_meta_tags[value] || meta_tags.extract(value)
                            else
                              value
                            end

--- a/spec/view_helper/open_graph_spec.rb
+++ b/spec/view_helper/open_graph_spec.rb
@@ -59,9 +59,9 @@ RSpec.describe MetaTags::ViewHelper, 'displaying Open Graph meta tags' do
   end
 
   it "displays mirrored content" do
-    subject.set_meta_tags(title: 'someTitle')
-    subject.display_meta_tags(open_graph: { title: :title }).tap do |meta|
-      expect(meta).to have_tag('meta', with: { content: "someTitle", property: "og:title" })
+    subject.set_meta_tags(canonical_link: 'https://example.org')
+    subject.display_meta_tags(open_graph: { url: :canonical_link }).tap do |meta|
+      expect(meta).to have_tag('meta', with: { content: "https://example.org", property: "og:url" })
     end
   end
 


### PR DESCRIPTION
Besides only checking the normalized meta tags for mirrored values we can also check the plain `meta_tags` attribute. This supports, e.g. setting the `og:url` meta tag to the value of the `canonical_link` meta tag.

---

Let me know what you think - I came across this today as I was trying to achieve exactly this, setting the `og:url` to the `canonical_link` as I was already setting that. 