### PR TITLE
Fixed RBS type for Object#presence

### DIFF
--- a/sig/lib/_internal/rails.rbs
+++ b/sig/lib/_internal/rails.rbs
@@ -4,7 +4,7 @@ class ::Hash[unchecked out K, unchecked out V]
 end
 
 class ::Object
-  def presence: () -> String?
+  def presence: () -> self?
   def blank?: () -> bool
   def present?: () -> bool
 end


### PR DESCRIPTION
Addresses a concern raised in #237:

> I don't think the type signature for `::Object#presence` is right.
> 
> ```ruby
> class ::Object
>   def presence: () -> String?
> end
> ```
> 
> The definition of `presence` is:
> 
> ```ruby
> class Object
>   def presence
>     self if present?
>   end
> end
> ```
> 
> https://github.com/rails/rails/blob/f95c0b7e96eb36bc3efc0c5beffbb9e84ea664e4/activesupport/lib/active_support/core_ext/object/blank.rb#L45-L48
> 
> So, `presence` returns the receiver or nil, not String or nil.
> 
> Note: I'm very new to RBS, so I might be wrong here. I just looked at this PR, because Dependabot told me about meta-tags 2.17.0.

