### PR TITLE
Fallback to site name when title is empty in mirrored tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.18.0 (September 15, 2022) [☰](https://github.com/kpumuk/meta-tags/compare/v2.17.0...v2.18.0)
+
+Changes:
+
+- Fallback to site name when title is empty in mirrored tags ([243](https://github.com/kpumuk/meta-tags/pull/243))
+
 ## 2.17.0 (July 5, 2022) [☰](https://github.com/kpumuk/meta-tags/compare/v2.16.0...v2.17.0)
 
 Changes:

--- a/lib/meta_tags/meta_tags_collection.rb
+++ b/lib/meta_tags/meta_tags_collection.rb
@@ -70,14 +70,16 @@ module MetaTags
       with_defaults(defaults) { extract_full_title }
     end
 
-    # Constructs the title without site title (for normalized parameters).
+    # Constructs the title without site title (for normalized parameters). When title is empty,
+    # use the site title instead.
     #
     # @return [String] page title.
     #
     def page_title(defaults = {})
       old_site = @meta_tags[:site]
       @meta_tags[:site] = nil
-      with_defaults(defaults) { extract_full_title }
+      full_title = with_defaults(defaults) { extract_full_title }
+      full_title.presence || old_site
     ensure
       @meta_tags[:site] = old_site
     end

--- a/lib/meta_tags/meta_tags_collection.rb
+++ b/lib/meta_tags/meta_tags_collection.rb
@@ -79,7 +79,7 @@ module MetaTags
       old_site = @meta_tags[:site]
       @meta_tags[:site] = nil
       full_title = with_defaults(defaults) { extract_full_title }
-      full_title.presence || old_site
+      full_title.presence || old_site || ''
     ensure
       @meta_tags[:site] = old_site
     end

--- a/lib/meta_tags/version.rb
+++ b/lib/meta_tags/version.rb
@@ -2,6 +2,6 @@
 
 module MetaTags
   # Gem version.
-  VERSION = '2.17.0'
+  VERSION = '2.18.0'
   public_constant :VERSION
 end

--- a/spec/view_helper/open_graph_spec.rb
+++ b/spec/view_helper/open_graph_spec.rb
@@ -65,12 +65,21 @@ RSpec.describe MetaTags::ViewHelper, 'displaying Open Graph meta tags' do
     end
   end
 
-  it "properlies handle title and site title in mirrored content" do
+  it "properly handle title and site title in mirrored content" do
     subject.set_meta_tags(title: 'someTitle', site: 'someSite')
     subject.display_meta_tags(open_graph: { title: :title, site_name: :site, full_title: :full_title }).tap do |meta|
       expect(meta).to have_tag('meta', with: { content: "someTitle", property: "og:title" })
       expect(meta).to have_tag('meta', with: { content: "someSite", property: "og:site_name" })
       expect(meta).to have_tag('meta', with: { content: "someSite | someTitle", property: "og:full_title" })
+    end
+  end
+
+  it "uses site_title for mirrored title, when title is empty" do
+    subject.set_meta_tags(title: '', site: 'someSite')
+    subject.display_meta_tags(open_graph: { title: :title, site_name: :site, full_title: :full_title }).tap do |meta|
+      expect(meta).to have_tag('meta', with: { content: "someSite", property: "og:title" })
+      expect(meta).to have_tag('meta', with: { content: "someSite", property: "og:site_name" })
+      expect(meta).to have_tag('meta', with: { content: "someSite", property: "og:full_title" })
     end
   end
 


### PR DESCRIPTION
Addresses the edge case when a title is not specified, but requested as an open-graph mirrored attribute. In this case, we should render the site title instead.

Closes #242 