### PR TITLE
Updating CodeClimate configuration to the latest version

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,4 +1,5 @@
-engines:
+version: "2"
+plugins:
   duplication:
     enabled: true
     config:
@@ -13,10 +14,6 @@ engines:
     # Check https://github.com/codeclimate/codeclimate-rubocop/branches/all?query=channel%2Frubocop
     channel: rubocop-1-31-0
 
-ratings:
-  paths:
-  - "**.rb"
-
-exclude_paths:
+exclude_patterns:
 - spec/**/*
 - certs/**/*


### PR DESCRIPTION
No functional changes in the configuration, addressing warnings:

```
WARNING: 'engines' has been deprecated, please use 'plugins' instead
WARNING: 'exclude_paths' has been deprecated, please use 'exclude_patterns' instead
WARNING: 'ratings' has been deprecated, and will not be used
```

* `engines` has been changed to `plugins`
* `exclude_paths` has been changed to `exclude_patterns`
* `ratings` has been deprecated, all files will receive maintainability ratings by default.