### PR TITLE
Switching to standard gem for Ruby styling

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -4,16 +4,11 @@ plugins:
     enabled: true
     config:
       languages:
-      - ruby
+        - ruby
 
   fixme:
     enabled: true
 
-  rubocop:
-    enabled: true
-    # Check https://github.com/codeclimate/codeclimate-rubocop/branches/all?query=channel%2Frubocop
-    channel: rubocop-1-35-1
-
 exclude_patterns:
-- spec/**/*
-- certs/**/*
+  - spec/**/*
+  - certs/**/*

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -12,7 +12,7 @@ plugins:
   rubocop:
     enabled: true
     # Check https://github.com/codeclimate/codeclimate-rubocop/branches/all?query=channel%2Frubocop
-    channel: rubocop-1-31-0
+    channel: rubocop-1-35-1
 
 exclude_patterns:
 - spec/**/*

--- a/.github/workflows/standard.yml
+++ b/.github/workflows/standard.yml
@@ -1,0 +1,13 @@
+name: StandardRB
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: StandardRB Linter
+        uses: andrewmcodes/standardrb-action@v1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,11 @@
 require:
+  - standard
   - rubocop-rails
+  - rubocop-rake
   - rubocop-rspec
+
+inherit_gem:
+  standard: config/base.yml
 
 AllCops:
   # Enable all the rules by default
@@ -11,92 +16,8 @@ AllCops:
   DisplayCopNames: true
   SuggestExtensions: false
   # Target versions
-  # We do not specify Ruby version, because CodeClimate should by default
-  # read .ruby-version, and send it down to Rubocop
-  # (see https://github.com/codeclimate/codeclimate-rubocop/pull/68)
   TargetRubyVersion: 2.6
-  # We will lock Rails version to the newest we have in the company, so we're
-  # always looking to the future.
   TargetRailsVersion: 5.1
-  # Exclude auto-generated and vendored files
-  Exclude:
-    - "db/schema.rb"
-
-#-------------------------------------------------------------------------------
-# Rules configuration
-#-------------------------------------------------------------------------------
-
-Bundler/OrderedGems:
-  TreatCommentsAsGroupSeparators: true
-
-Layout/HashAlignment:
-  EnforcedColonStyle: table
-  EnforcedHashRocketStyle: table
-  EnforcedLastArgumentHashStyle: always_inspect
-
-Layout/DotPosition:
-  EnforcedStyle: trailing
-
-Layout/LineLength:
-  Max: 120
-  Exclude:
-    - "spec/**/*"
-
-Layout/MultilineAssignmentLayout:
-  EnforcedStyle: same_line
-
-Layout/MultilineMethodCallIndentation:
-  EnforcedStyle: indented_relative_to_receiver
-
-# Requere spaces inside of brackets, e.g. [ 1, 2, 3 ]
-Layout/SpaceInsideArrayLiteralBrackets:
-  Enabled: false
-  EnforcedStyle: compact
-
-Metrics/AbcSize:
-  Max: 25
-
-Metrics/BlockLength:
-  Exclude:
-    - "**/*.rake"
-    - "spec/**/*_spec.rb"
-    - "spec/spec_helper.rb"
-    - "meta-tags.gemspec"
-
-Metrics/ClassLength:
-  Max: 250
-  CountComments: false
-
-Metrics/MethodLength:
-  Max: 30
-
-Metrics/ModuleLength:
-  Max: 250
-  CountComments: false
-
-Rails/SafeNavigation:
-  ConvertTry: true
-
-Style/Alias:
-  EnforcedStyle: prefer_alias_method
-
-Style/ClassCheck:
-  EnforcedStyle: kind_of?
-
-Style/Lambda:
-  EnforcedStyle: literal
-
-Style/TrailingCommaInArguments:
-  EnforcedStyleForMultiline: consistent_comma
-
-Style/TrailingCommaInArrayLiteral:
-  EnforcedStyleForMultiline: consistent_comma
-
-Style/TrailingCommaInHashLiteral:
-  EnforcedStyleForMultiline: consistent_comma
-
-Style/BlockDelimiters:
-  EnforcedStyle: braces_for_chaining
 
 #-------------------------------------------------------------------------------
 # RSpec rules
@@ -130,97 +51,10 @@ RSpec/VerifiedDoubles:
 # Disabled rules
 #-------------------------------------------------------------------------------
 
-# Yes, we have meta-tags.rb for simplicity
-Naming/FileName:
-  Enabled: false
-
-# Allow not null columns without a default value
-Rails/NotNullColumn:
-  Enabled: false
-
 # Do not require loading Rails enviroment for Rake tasks as we are not a Rails application.
 Rails/RakeEnvironment:
   Enabled: false
 
 # Do not require subclassing from ApplicationController as we're not a rails application
 Rails/ApplicationController:
-  Enabled: false
-
-# This check does not distinguish between "private :x" and "private def x"
-Style/AccessModifierDeclarations:
-  Enabled: false
-
-Style/ClassAndModuleChildren:
-  Enabled: false
-
-# Do not require copyright information
-Style/Copyright:
-  Enabled: false
-
-# Do not require class and module documentation
-Style/Documentation:
-  Enabled: false
-
-# Do not require method documentation
-Style/DocumentationMethod:
-  Enabled: false
-
-# Allow double negation (!!@var)
-Style/DoubleNegation:
-  Enabled: false
-
-# Do not enforce if modifier, sometimes it is better to split for long lines
-Style/IfUnlessModifier:
-  Enabled: false
-
-# Allow trailing comments
-Style/InlineComment:
-  Enabled: false
-
-# Do not require parentheses around method arguments
-Style/MethodCallWithArgsParentheses:
-  Enabled: false
-
-# Do not enforce `else` on conditions
-Style/MissingElse:
-  Enabled: false
-
-# Allow both `.positive?` and `> 0` variants
-Style/NumericPredicate:
-  Enabled: false
-
-# Do not enforce using symbols for hash keys
-Style/StringHashKeys:
-  Enabled: false
-
-# Do not enforce usage of single quotes on strings
-Style/StringLiterals:
-  Enabled: false
-
-# Do not require to use %i[] around symbol arrays
-Style/SymbolArray:
-  Enabled: false
-
-# Do not require to use %w[] around word arrays
-Style/WordArray:
-  Enabled: false
-
-# Do not prohibit explicit Rubocop enable/disable directives
-Style/DisableCopsWithinSourceCodeDirective:
-  Enabled: false
-
-# Do not require keyword arguments when defining method with boolean argument (historical API)
-Style/OptionalBooleanParameter:
-  Enabled: false
-
-# Do not require fully qualified constants
-Lint/ConstantResolution:
-  Enabled: false
-
-# Bundler is only used for gem development
-Bundler/GemVersion:
-  Enabled: false
-
-# Developers can decide where to put their line breaks, thank you very much
-Layout/RedundantLineBreak:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.19.0 (Development)
+
+Changes:
+
+- Switched code style from custom rules to Standard ([246](https://github.com/kpumuk/meta-tags/pull/246)).
+
 ## 2.18.0 (September 15, 2022) [☰](https://github.com/kpumuk/meta-tags/compare/v2.17.0...v2.18.0)
 
 Changes:
@@ -10,7 +16,7 @@ Changes:
 
 Changes:
 
-- Separate RBS files to _internal directory to avoid exposing RBS ([237](https://github.com/kpumuk/meta-tags/pull/237))
+- Separate RBS files to \_internal directory to avoid exposing RBS ([237](https://github.com/kpumuk/meta-tags/pull/237))
 - Added Ruby 3.1 to supported versions, Ruby 2.6 is minimum supported version ([235](https://github.com/kpumuk/meta-tags/pull/235/))
 
 ## 2.16.0 (September 24, 2021) [☰](https://github.com/kpumuk/meta-tags/compare/v2.15.0...v2.16.0)

--- a/Gemfile
+++ b/Gemfile
@@ -1,30 +1,32 @@
 # frozen_string_literal: true
 
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in meta-tags.gemspec
 gemspec
 
-if ENV['RAILS_VERSION']
+if ENV["RAILS_VERSION"]
   # Install specified version of actionpack if requested
-  gem 'railties', "~> #{ENV['RAILS_VERSION']}"
+  gem "railties", "~> #{ENV["RAILS_VERSION"]}"
 end
 
-unless ENV["NO_STEEP"] == '1'
+unless ENV["NO_STEEP"] == "1"
   # Ruby typings
-  gem 'steep', '~> 1.1.1', platform: :mri
+  gem "steep", "~> 1.1.1", platform: :mri
 end
 
 group :test do
   # Lock rubocop to a specific version we use on CI. If you update this,
   # don't forget to switch rubocop channel in the .codeclimate.yml
-  gem 'rubocop', '= 1.31.0'
+  gem "rubocop", "= 1.35.1"
   # Cops for rails apps
-  gem 'rubocop-rails'
+  gem "rubocop-rails"
+  # Cops for rake tasks
+  gem "rubocop-rake"
   # Apply RSpec rubocop cops
-  gem 'rubocop-rspec', require: false
+  gem "rubocop-rspec", require: false
   # We use this gem on CI to calculate code coverage.
-  gem 'simplecov', '~> 0.21.2'
+  gem "simplecov", "~> 0.21.2"
   # Format RSpec output for CircleCI
-  gem 'rspec_junit_formatter'
+  gem "rspec_junit_formatter"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -16,9 +16,8 @@ unless ENV["NO_STEEP"] == "1"
 end
 
 group :test do
-  # Lock rubocop to a specific version we use on CI. If you update this,
-  # don't forget to switch rubocop channel in the .codeclimate.yml
-  gem "rubocop", "= 1.35.1"
+  # Ruby Style Guide, with linter & automatic code fixer
+  gem "standard"
   # Cops for rails apps
   gem "rubocop-rails"
   # Cops for rake tasks

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CircleCI](https://circleci.com/gh/kpumuk/meta-tags.svg?style=shield)](https://circleci.com/gh/kpumuk/meta-tags)
 [![Gem Version](https://badge.fury.io/rb/meta-tags.svg)](https://badge.fury.io/rb/meta-tags)
+[![Ruby Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://github.com/testdouble/standard)
 [![Code Climate](https://codeclimate.com/github/kpumuk/meta-tags/badges/gpa.svg)](https://codeclimate.com/github/kpumuk/meta-tags)
 [![Test Coverage](https://codeclimate.com/github/kpumuk/meta-tags/badges/coverage.svg)](https://codeclimate.com/github/kpumuk/meta-tags/coverage)
 [![Gem Downloads](https://img.shields.io/gem/dt/meta-tags.svg)](https://badge.fury.io/rb/meta-tags)

--- a/Rakefile
+++ b/Rakefile
@@ -1,19 +1,20 @@
 # frozen_string_literal: true
 
-require 'bundler'
+require "bundler"
 Bundler::GemHelper.install_tasks
 
-require 'rspec/core/rake_task'
+require "rspec/core/rake_task"
 RSpec::Core::RakeTask.new(:spec)
 
+desc "Run RSpec tests"
 task test: :spec
 task default: :spec
 
-desc 'Rebuild Circle CI configuration based on the build matrix template .circleci/config.yml.erb'
+desc "Rebuild Circle CI configuration based on the build matrix template .circleci/config.yml.erb"
 task :circleci do
-  require 'erb'
-  template_path = File.expand_path('.circleci/config.yml.erb', __dir__)
-  config_path = File.expand_path('.circleci/config.yml', __dir__)
+  require "erb"
+  template_path = File.expand_path(".circleci/config.yml.erb", __dir__)
+  config_path = File.expand_path(".circleci/config.yml", __dir__)
   File.write config_path, ERB.new(File.read(template_path)).result
 end
 
@@ -26,24 +27,30 @@ module SteepRunner
   end
 end
 
-task :steep do
-  SteepRunner.run("check")
-end
+desc "Check type information"
+task steep: "steep:check"
 
 namespace :steep do
+  desc "Check type information"
+  task :check do
+    SteepRunner.run("check")
+  end
+
+  desc "Print type statistics"
   task :stats do
     SteepRunner.run("stats", "--log-level=fatal")
   end
 end
 
 namespace :rbs do
+  desc "Run RSpec tests with RBS enabled to test type signatures"
   task :spec do
     exec(
       {
-        'RBS_TEST_TARGET' => 'MetaTags::*',
-        'RUBYOPT'         => '-rrbs/test/setup',
+        "RBS_TEST_TARGET" => "MetaTags::*",
+        "RUBYOPT" => "-rrbs/test/setup"
       },
-      'bundle exec rspec',
+      "bundle exec rspec"
     )
   end
 end

--- a/lib/generators/meta_tags/install_generator.rb
+++ b/lib/generators/meta_tags/install_generator.rb
@@ -4,7 +4,7 @@ module MetaTags
   module Generators
     class InstallGenerator < Rails::Generators::Base
       desc "Copy MetaTags default files"
-      source_root File.expand_path('templates', __dir__)
+      source_root File.expand_path("templates", __dir__)
 
       def copy_config
         template "config/initializers/meta_tags.rb"

--- a/lib/meta-tags.rb
+++ b/lib/meta-tags.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-require 'meta_tags'
+require "meta_tags"

--- a/lib/meta_tags.rb
+++ b/lib/meta_tags.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'set'
-require 'active_support/core_ext/hash/indifferent_access'
+require "set"
+require "active_support/core_ext/hash/indifferent_access"
 
 # MetaTags gem namespace.
 module MetaTags
@@ -24,15 +24,15 @@ module MetaTags
   end
 end
 
-require 'meta_tags/version'
+require "meta_tags/version"
 
-require 'meta_tags/configuration'
-require 'meta_tags/controller_helper'
-require 'meta_tags/meta_tags_collection'
-require 'meta_tags/renderer'
-require 'meta_tags/tag'
-require 'meta_tags/content_tag'
-require 'meta_tags/text_normalizer'
-require 'meta_tags/view_helper'
+require "meta_tags/configuration"
+require "meta_tags/controller_helper"
+require "meta_tags/meta_tags_collection"
+require "meta_tags/renderer"
+require "meta_tags/tag"
+require "meta_tags/content_tag"
+require "meta_tags/text_normalizer"
+require "meta_tags/view_helper"
 
-require 'meta_tags/railtie' if defined?(Rails)
+require "meta_tags/railtie" if defined?(Rails)

--- a/lib/meta_tags/configuration.rb
+++ b/lib/meta_tags/configuration.rb
@@ -47,25 +47,25 @@ module MetaTags
     def default_property_tags
       [
         # App Link metadata https://developers.facebook.com/docs/applinks/metadata-reference
-        'al',
+        "al",
         # Open Graph Markup https://developers.facebook.com/docs/sharing/webmasters#markup
-        'fb',
-        'og',
+        "fb",
+        "og",
         # Facebook OpenGraph Object Types https://developers.facebook.com/docs/reference/opengraph
         # Note that these tags are used in a regex, so including e.g. 'restaurant' will affect
         # 'restaurant:category', 'restaurant:price_rating', and anything else under that namespace.
-        'article',
-        'book',
-        'books',
-        'business',
-        'fitness',
-        'game',
-        'music',
-        'place',
-        'product',
-        'profile',
-        'restaurant',
-        'video',
+        "article",
+        "book",
+        "books",
+        "business",
+        "fitness",
+        "game",
+        "music",
+        "place",
+        "product",
+        "profile",
+        "restaurant",
+        "video"
       ].freeze
     end
 
@@ -78,7 +78,7 @@ module MetaTags
       @truncate_site_title_first = false
       @description_limit = 300
       @keywords_limit = 255
-      @keywords_separator = ', '
+      @keywords_separator = ", "
       @keywords_lowercase = true
       @property_tags = default_property_tags.dup
       @open_meta_tags = true

--- a/lib/meta_tags/controller_helper.rb
+++ b/lib/meta_tags/controller_helper.rb
@@ -15,8 +15,8 @@ module MetaTags
     # Processes the <tt>@page_title</tt>, <tt>@page_keywords</tt>, and
     # <tt>@page_description</tt> instance variables and calls +render+.
     def render(*args, &block)
-      meta_tags[:title]       = @page_title       if defined?(@page_title) && @page_title
-      meta_tags[:keywords]    = @page_keywords    if defined?(@page_keywords) && @page_keywords
+      meta_tags[:title] = @page_title if defined?(@page_title) && @page_title
+      meta_tags[:keywords] = @page_keywords if defined?(@page_keywords) && @page_keywords
       meta_tags[:description] = @page_description if defined?(@page_description) && @page_description
 
       super
@@ -25,7 +25,7 @@ module MetaTags
     # Set meta tags for the page.
     #
     # See <tt>MetaTags::ViewHelper#set_meta_tags</tt> for details.
-    def set_meta_tags(meta_tags) # rubocop:disable Naming/AccessorMethodName
+    def set_meta_tags(meta_tags)
       self.meta_tags.update(meta_tags)
     end
     protected :set_meta_tags

--- a/lib/meta_tags/meta_tags_collection.rb
+++ b/lib/meta_tags/meta_tags_collection.rb
@@ -188,7 +188,7 @@ module MetaTags
     # @return [String] separator segment value.
     #
     def extract_separator_section(name, default)
-      meta_tags[name] == false ? "" : (meta_tags[name] || default)
+      (meta_tags[name] == false) ? "" : (meta_tags[name] || default)
     end
 
     # Extracts robots attribute (noindex, nofollow, etc) name and value.
@@ -198,7 +198,7 @@ module MetaTags
     #
     def extract_robots_attribute(name)
       noindex = extract(name)
-      noindex_name = noindex.is_a?(String) || noindex.is_a?(Array) ? noindex : "robots"
+      noindex_name = (noindex.is_a?(String) || noindex.is_a?(Array)) ? noindex : "robots"
       noindex_value = noindex ? name.to_s : nil
 
       [noindex_name, noindex_value]

--- a/lib/meta_tags/meta_tags_collection.rb
+++ b/lib/meta_tags/meta_tags_collection.rb
@@ -39,12 +39,12 @@ module MetaTags
     #
     def update(object = {})
       meta_tags = if object.respond_to?(:to_meta_tags)
-                    # @type var object: (_MetaTagish & Object)
-                    object.to_meta_tags
-                  else
-                    # @type var object: Hash[String | Symbol, untyped]
-                    object
-                  end
+        # @type var object: (_MetaTagish & Object)
+        object.to_meta_tags
+      else
+        # @type var object: Hash[String | Symbol, untyped]
+        object
+      end
       @meta_tags.deep_merge! normalize_open_graph(meta_tags)
     end
 
@@ -79,7 +79,7 @@ module MetaTags
       old_site = @meta_tags[:site]
       @meta_tags[:site] = nil
       full_title = with_defaults(defaults) { extract_full_title }
-      full_title.presence || old_site || ''
+      full_title.presence || old_site || ""
     ensure
       @meta_tags[:site] = old_site
     end
@@ -106,10 +106,10 @@ module MetaTags
     # @return [String] page title.
     #
     def extract_full_title
-      site_title = extract(:site) || ''
-      title      = extract_title
-      separator  = extract_separator
-      reverse    = extract(:reverse) == true
+      site_title = extract(:site) || ""
+      title = extract_title
+      separator = extract_separator
+      reverse = extract(:reverse) == true
 
       TextNormalizer.normalize_title(site_title, title, separator, reverse)
     end
@@ -136,15 +136,15 @@ module MetaTags
     def extract_separator
       if meta_tags[:separator] == false
         # Special case: if separator is hidden, do not display suffix/prefix
-        prefix = separator = suffix = ''
+        prefix = separator = suffix = ""
       else
-        prefix    = extract_separator_section(:prefix, ' ')
-        separator = extract_separator_section(:separator, '|')
-        suffix    = extract_separator_section(:suffix, ' ')
+        prefix = extract_separator_section(:prefix, " ")
+        separator = extract_separator_section(:separator, "|")
+        suffix = extract_separator_section(:suffix, " ")
       end
       delete(:separator, :prefix, :suffix)
 
-      TextNormalizer.safe_join([prefix, separator, suffix], '')
+      TextNormalizer.safe_join([prefix, separator, suffix], "")
     end
 
     # Extracts noindex settings as a Hash mapping noindex tag name to value.
@@ -159,12 +159,12 @@ module MetaTags
         [:noindex, :index],
         # follow has higher priority than nofollow
         [:follow, :nofollow],
-        :noarchive,
+        :noarchive
       ].each do |attributes|
         calculate_robots_attributes(result, attributes)
       end
 
-      result.transform_values { |v| v.join(', ') }
+      result.transform_values { |v| v.join(", ") }
     end
 
     protected
@@ -188,7 +188,7 @@ module MetaTags
     # @return [String] separator segment value.
     #
     def extract_separator_section(name, default)
-      meta_tags[name] == false ? '' : (meta_tags[name] || default)
+      meta_tags[name] == false ? "" : (meta_tags[name] || default)
     end
 
     # Extracts robots attribute (noindex, nofollow, etc) name and value.
@@ -197,11 +197,11 @@ module MetaTags
     # @return [Array<String>] pair of noindex attribute name and value.
     #
     def extract_robots_attribute(name)
-      noindex       = extract(name)
-      noindex_name  = noindex.kind_of?(String) || noindex.kind_of?(Array) ? noindex : 'robots'
+      noindex = extract(name)
+      noindex_name = noindex.is_a?(String) || noindex.is_a?(Array) ? noindex : "robots"
       noindex_value = noindex ? name.to_s : nil
 
-      [ noindex_name, noindex_value ]
+      [noindex_name, noindex_value]
     end
 
     def calculate_robots_attributes(result, attributes)

--- a/lib/meta_tags/railtie.rb
+++ b/lib/meta_tags/railtie.rb
@@ -2,13 +2,13 @@
 
 module MetaTags
   class Railtie < Rails::Railtie
-    initializer 'meta_tags.setup_action_controller' do
+    initializer "meta_tags.setup_action_controller" do
       ActiveSupport.on_load :action_controller do
         ActionController::Base.include MetaTags::ControllerHelper
       end
     end
 
-    initializer 'meta_tags.setup_action_view' do
+    initializer "meta_tags.setup_action_view" do
       ActiveSupport.on_load :action_view do
         ActionView::Base.include MetaTags::ViewHelper
       end

--- a/lib/meta_tags/renderer.rb
+++ b/lib/meta_tags/renderer.rb
@@ -71,12 +71,12 @@ module MetaTags
       return unless icon
 
       # String? Value is an href
-      icon = [{ href: icon }] if icon.kind_of?(String)
+      icon = [{href: icon}] if icon.is_a?(String)
       # Hash? Single icon instead of a list of icons
-      icon = [icon] if icon.kind_of?(Hash)
+      icon = [icon] if icon.is_a?(Hash)
 
       icon.each do |icon_params|
-        icon_params = { rel: 'icon', type: 'image/x-icon' }.with_indifferent_access.merge(icon_params)
+        icon_params = {rel: "icon", type: "image/x-icon"}.with_indifferent_access.merge(icon_params)
         tags << Tag.new(:link, icon_params)
       end
     end
@@ -109,7 +109,7 @@ module MetaTags
     #
     def render_refresh(tags)
       refresh = meta_tags.extract(:refresh)
-      tags << Tag.new(:meta, 'http-equiv' => 'refresh', content: refresh.to_s) if refresh.present?
+      tags << Tag.new(:meta, "http-equiv" => "refresh", :content => refresh.to_s) if refresh.present?
     end
 
     # Renders alternate link tags.
@@ -120,13 +120,13 @@ module MetaTags
       alternate = meta_tags.extract(:alternate)
       return unless alternate
 
-      if alternate.kind_of?(Hash)
+      if alternate.is_a?(Hash)
         alternate.each do |hreflang, href|
-          tags << Tag.new(:link, rel: 'alternate', href: href, hreflang: hreflang) if href.present?
+          tags << Tag.new(:link, rel: "alternate", href: href, hreflang: hreflang) if href.present?
         end
-      elsif alternate.kind_of?(Array)
+      elsif alternate.is_a?(Array)
         alternate.each do |link_params|
-          tags << Tag.new(:link, { rel: 'alternate' }.with_indifferent_access.merge(link_params))
+          tags << Tag.new(:link, {rel: "alternate"}.with_indifferent_access.merge(link_params))
         end
       end
     end
@@ -143,7 +143,7 @@ module MetaTags
       title = open_search[:title]
 
       type = "application/opensearchdescription+xml"
-      tags << Tag.new(:link, rel: 'search', type: type, href: href, title: title) if href.present?
+      tags << Tag.new(:link, rel: "search", type: type, href: href, title: title) if href.present?
     end
 
     # Renders links.
@@ -151,7 +151,7 @@ module MetaTags
     # @param [Array<Tag>] tags a buffer object to store tag in.
     #
     def render_links(tags)
-      [ :amphtml, :prev, :next, :image_src, :manifest ].each do |tag_name|
+      [:amphtml, :prev, :next, :image_src, :manifest].each do |tag_name|
         href = meta_tags.extract(tag_name)
         if href.present?
           @normalized_meta_tags[tag_name] = href
@@ -189,7 +189,7 @@ module MetaTags
     #
     def render_hash(tags, key, **opts)
       data = meta_tags.meta_tags[key]
-      return unless data.kind_of?(Hash)
+      return unless data.is_a?(Hash)
 
       process_hash(tags, key, data, **opts)
       meta_tags.extract(key)
@@ -202,7 +202,7 @@ module MetaTags
     def render_custom(tags)
       meta_tags.meta_tags.each do |name, data|
         Array(data).each do |val|
-          tags << Tag.new(:meta, configured_name_key(name) => name, content: val)
+          tags << Tag.new(:meta, configured_name_key(name) => name, :content => val)
         end
         meta_tags.extract(name)
       end
@@ -217,14 +217,14 @@ module MetaTags
     #
     def process_tree(tags, property, content, itemprop: nil, **opts)
       method = case content
-               when Hash
-                 :process_hash
-               when Array
-                 :process_array
-               else
-                 iprop = itemprop
-                 :render_tag
-               end
+      when Hash
+        :process_hash
+      when Array
+        :process_array
+      else
+        iprop = itemprop
+        :render_tag
+      end
       __send__(method, tags, property, content, itemprop: iprop, **opts)
     end
 
@@ -237,18 +237,18 @@ module MetaTags
     def process_hash(tags, property, content, **opts)
       itemprop = content.delete(:itemprop)
       content.each do |key, value|
-        if key.to_s == '_'
+        if key.to_s == "_"
           iprop = itemprop
           key = property
         else
           key = "#{property}:#{key}"
         end
 
-        normalized_value = if value.kind_of?(Symbol)
-                             normalized_meta_tags[value]
-                           else
-                             value
-                           end
+        normalized_value = if value.is_a?(Symbol)
+          normalized_meta_tags[value]
+        else
+          value
+        end
         process_tree(tags, key, normalized_value, **opts.merge(itemprop: iprop))
       end
     end
@@ -273,7 +273,7 @@ module MetaTags
     #
     def render_tag(tags, name, value, itemprop: nil)
       name_key ||= configured_name_key(name)
-      tags << Tag.new(:meta, name_key => name.to_s, content: value, itemprop: itemprop) if value.present?
+      tags << Tag.new(:meta, name_key => name.to_s, :content => value, :itemprop => itemprop) if value.present?
     end
 
     # Returns meta tag property name for a give meta tag based on the

--- a/lib/meta_tags/text_normalizer.rb
+++ b/lib/meta_tags/text_normalizer.rb
@@ -44,7 +44,7 @@ module MetaTags
       # serves the same purpose we could just as it to convert itself to str
       # and continue from there
       description = cleanup_string(description)
-      return '' if description.blank?
+      return "" if description.blank?
 
       truncate(description, MetaTags.config.description_limit)
     end
@@ -56,7 +56,7 @@ module MetaTags
     #
     def normalize_keywords(keywords)
       keywords = cleanup_strings(keywords)
-      return '' if keywords.blank?
+      return "" if keywords.blank?
 
       keywords.each(&:downcase!) if MetaTags.config.keywords_lowercase
       separator = cleanup_string MetaTags.config.keywords_separator, strip: false
@@ -107,12 +107,12 @@ module MetaTags
     # space characters squashed into a single space.
     #
     def cleanup_string(string, strip: true)
-      return '' if string.nil?
-      raise ArgumentError, 'Expected a string or an object that implements #to_str' unless string.respond_to?(:to_str)
+      return "" if string.nil?
+      raise ArgumentError, "Expected a string or an object that implements #to_str" unless string.respond_to?(:to_str)
 
       s = strip_tags(string.to_str)
       s = s.dup if s.frozen?
-      s.gsub!(/\s+/, ' ')
+      s.gsub!(/\s+/, " ")
       s.strip! if strip
 
       s
@@ -137,15 +137,15 @@ module MetaTags
     # @param [String] natural_separator natural separator to truncate at.
     # @return [String] truncated string.
     #
-    def truncate(string, limit = nil, natural_separator = ' ')
-      return string if limit.to_i == 0 # rubocop:disable Lint/NumberConversion
+    def truncate(string, limit = nil, natural_separator = " ")
+      return string if limit.to_i == 0
 
       helpers.truncate(
         string,
-        length:    limit,
+        length: limit,
         separator: natural_separator,
-        omission:  '',
-        escape:    true,
+        omission: "",
+        escape: true
       )
     end
 
@@ -157,7 +157,7 @@ module MetaTags
     # @param [String] natural_separator natural separator to truncate at.
     # @return [Array<String>] truncated array of strings.
     #
-    def truncate_array(string_array, limit = nil, separator = '', natural_separator = ' ')
+    def truncate_array(string_array, limit = nil, separator = "", natural_separator = " ")
       return string_array if limit.nil? || limit <= 0
 
       length = 0
@@ -188,10 +188,10 @@ module MetaTags
     end
 
     def truncate_title(site_title, title, separator)
-      global_limit = MetaTags.config.title_limit.to_i # rubocop:disable Lint/NumberConversion
+      global_limit = MetaTags.config.title_limit.to_i
       if global_limit > 0
         site_title_limited_length, title_limited_length = calculate_title_limits(
-          site_title, title, separator, global_limit,
+          site_title, title, separator, global_limit
         )
 
         title = title_limited_length > 0 ? truncate_array(title, title_limited_length, separator) : []
@@ -212,9 +212,9 @@ module MetaTags
       secondary_limited_length = [0, secondary_limited_length].max
 
       if MetaTags.config.truncate_site_title_first
-        [ secondary_limited_length, main_limited_length ]
+        [secondary_limited_length, main_limited_length]
       else
-        [ main_limited_length, secondary_limited_length ]
+        [main_limited_length, secondary_limited_length]
       end
     end
   end

--- a/lib/meta_tags/text_normalizer.rb
+++ b/lib/meta_tags/text_normalizer.rb
@@ -194,8 +194,8 @@ module MetaTags
           site_title, title, separator, global_limit
         )
 
-        title = title_limited_length > 0 ? truncate_array(title, title_limited_length, separator) : []
-        site_title = site_title_limited_length > 0 ? truncate(site_title, site_title_limited_length) : nil
+        title = (title_limited_length > 0) ? truncate_array(title, title_limited_length, separator) : []
+        site_title = (site_title_limited_length > 0) ? truncate(site_title, site_title_limited_length) : nil
       end
 
       [site_title, title]
@@ -208,7 +208,7 @@ module MetaTags
       main_length = main_title.map(&:length).sum + ((main_title.size - 1) * separator.length)
       main_limited_length = global_limit
 
-      secondary_limited_length = global_limit - (main_length > 0 ? main_length + separator.length : 0)
+      secondary_limited_length = global_limit - ((main_length > 0) ? main_length + separator.length : 0)
       secondary_limited_length = [0, secondary_limited_length].max
 
       if MetaTags.config.truncate_site_title_first

--- a/lib/meta_tags/version.rb
+++ b/lib/meta_tags/version.rb
@@ -2,6 +2,6 @@
 
 module MetaTags
   # Gem version.
-  VERSION = '2.18.0'
+  VERSION = "2.18.0"
   public_constant :VERSION
 end

--- a/lib/meta_tags/view_helper.rb
+++ b/lib/meta_tags/view_helper.rb
@@ -55,7 +55,7 @@ module MetaTags
     #
     # @see #display_meta_tags
     #
-    def title(title = nil, headline = '')
+    def title(title = nil, headline = "")
       set_meta_tags(title: title) unless title.nil?
       headline.presence || meta_tags[:title]
     end

--- a/meta-tags.gemspec
+++ b/meta-tags.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.11.0"
   spec.add_development_dependency "rspec-html-matchers", "~> 0.10.0"
-  spec.add_development_dependency "standard", "~> 1.16.1"
+  spec.add_development_dependency "standard", "~> 1.18.1"
 
   spec.cert_chain = ["certs/kpumuk.pem"]
   spec.signing_key = File.expand_path("~/.ssh/gem-kpumuk.pem") if $PROGRAM_NAME.end_with?("gem")

--- a/meta-tags.gemspec
+++ b/meta-tags.gemspec
@@ -1,25 +1,25 @@
 # frozen_string_literal: true
 
-lib = File.expand_path('lib', __dir__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'meta_tags/version'
+require "meta_tags/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "meta-tags"
-  spec.version       = MetaTags::VERSION
-  spec.authors       = ["Dmytro Shteflyuk"]
-  spec.email         = ["kpumuk@kpumuk.info"]
+  spec.name = "meta-tags"
+  spec.version = MetaTags::VERSION
+  spec.authors = ["Dmytro Shteflyuk"]
+  spec.email = ["kpumuk@kpumuk.info"]
 
-  spec.summary       = "Collection of SEO helpers for Ruby on Rails."
-  spec.description   = "Search Engine Optimization (SEO) plugin for Ruby on Rails applications."
-  spec.homepage      = "https://github.com/kpumuk/meta-tags"
-  spec.license       = "MIT"
-  spec.platform      = Gem::Platform::RUBY
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.summary = "Collection of SEO helpers for Ruby on Rails."
+  spec.description = "Search Engine Optimization (SEO) plugin for Ruby on Rails applications."
+  spec.homepage = "https://github.com/kpumuk/meta-tags"
+  spec.license = "MIT"
+  spec.platform = Gem::Platform::RUBY
+  spec.required_ruby_version = ">= 2.6.0"
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(\.|(bin|test|spec|features)/)}) }
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(\.|(bin|test|spec|features)/)}) }
+  spec.bindir = "exe"
+  spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   spec.add_dependency "actionpack", ">= 3.2.0", "< 7.1"
@@ -28,16 +28,17 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.11.0"
   spec.add_development_dependency "rspec-html-matchers", "~> 0.10.0"
+  spec.add_development_dependency "standard", "~> 1.16.1"
 
-  spec.cert_chain    = ["certs/kpumuk.pem"]
-  spec.signing_key   = File.expand_path("~/.ssh/gem-kpumuk.pem") if $PROGRAM_NAME.end_with?('gem')
+  spec.cert_chain = ["certs/kpumuk.pem"]
+  spec.signing_key = File.expand_path("~/.ssh/gem-kpumuk.pem") if $PROGRAM_NAME.end_with?("gem")
 
   spec.metadata = {
-    "bug_tracker_uri"       => "https://github.com/kpumuk/meta-tags/issues/",
-    "changelog_uri"         => "https://github.com/kpumuk/meta-tags/blob/main/CHANGELOG.md",
-    "documentation_uri"     => "https://rubydoc.info/github/kpumuk/meta-tags/",
-    "homepage_uri"          => "https://github.com/kpumuk/meta-tags/",
-    "source_code_uri"       => "https://github.com/kpumuk/meta-tags/",
-    "rubygems_mfa_required" => "true",
+    "bug_tracker_uri" => "https://github.com/kpumuk/meta-tags/issues/",
+    "changelog_uri" => "https://github.com/kpumuk/meta-tags/blob/main/CHANGELOG.md",
+    "documentation_uri" => "https://rubydoc.info/github/kpumuk/meta-tags/",
+    "homepage_uri" => "https://github.com/kpumuk/meta-tags/",
+    "source_code_uri" => "https://github.com/kpumuk/meta-tags/",
+    "rubygems_mfa_required" => "true"
   }
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe MetaTags::Configuration do
-  it 'is returned by MetaTags.config' do
+  it "is returned by MetaTags.config" do
     expect(MetaTags.config).to be_instance_of(described_class)
   end
 
-  it 'is yielded by MetaTags.configure' do
+  it "is yielded by MetaTags.configure" do
     MetaTags.configure do |c|
       expect(c).to be_instance_of(described_class)
       expect(c).to be(MetaTags.config)

--- a/spec/controller_helper_spec.rb
+++ b/spec/controller_helper_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe MetaTags::ControllerHelper do
   subject do
@@ -14,8 +14,8 @@ RSpec.describe MetaTags::ControllerHelper do
     skip("Does not work properly with RBS") if ENV["RBS_TEST_TARGET"] # rubocop:disable RSpec/Pending
   end
 
-  describe 'module' do
-    it 'is mixed into ActionController::Base' do
+  describe "module" do
+    it "is mixed into ActionController::Base" do
       expect(ActionController::Base.included_modules).to include(described_class)
     end
 
@@ -24,25 +24,25 @@ RSpec.describe MetaTags::ControllerHelper do
     end
   end
 
-  describe '.render' do
-    it 'sets meta tags from instance variables' do
+  describe ".render" do
+    it "sets meta tags from instance variables" do
       subject.index
-      expect(subject.response.body).to eq('_rendered_')
-      expect(subject.meta_tags.meta_tags).to eq('title' => 'title', 'keywords' => 'key1, key2, key3', 'description' => 'description')
+      expect(subject.response.body).to eq("_rendered_")
+      expect(subject.meta_tags.meta_tags).to eq("title" => "title", "keywords" => "key1, key2, key3", "description" => "description")
     end
 
-    it 'does not require instance variables' do
+    it "does not require instance variables" do
       subject.show
-      expect(subject.response.body).to eq('_rendered_')
+      expect(subject.response.body).to eq("_rendered_")
       expect(subject.meta_tags.meta_tags).to eq({})
     end
 
-    it 'does not fail when instance variables are not set' do
+    it "does not fail when instance variables are not set" do
       subject.hide
-      expect(subject.response.body).to eq('_rendered_')
+      expect(subject.response.body).to eq("_rendered_")
       expect(subject.meta_tags.meta_tags).to eq({})
     end
   end
 
-  it_behaves_like '.set_meta_tags'
+  it_behaves_like ".set_meta_tags"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-if ENV['ENABLE_CODE_COVERAGE']
-  require 'simplecov'
+if ENV["ENABLE_CODE_COVERAGE"]
+  require "simplecov"
   SimpleCov.start do
     enable_coverage :branch
   end
 end
 
-require 'meta_tags'
-require 'rspec-html-matchers'
+require "meta_tags"
+require "rspec-html-matchers"
 
 Dir[File.expand_path("support/**/*.rb", __dir__)].sort.each { |f| require f }
 
@@ -22,7 +22,7 @@ RSpec.configure do |config|
     # Use the documentation formatter for detailed output,
     # unless a formatter has already been configured
     # (e.g. via a command-line flag).
-    config.formatter = 'doc' if config.formatters.none?
+    config.formatter = "doc" if config.formatters.none?
   end
 
   # Limits the available syntax to the non-monkey patched

--- a/spec/support/initialize_rails.rb
+++ b/spec/support/initialize_rails.rb
@@ -6,14 +6,14 @@
 #
 # TLDR. This is a real Rails application
 
-require 'rails'
-require 'action_controller/railtie'
-require 'action_view/railtie'
-require 'meta_tags/railtie'
+require "rails"
+require "action_controller/railtie"
+require "action_view/railtie"
+require "meta_tags/railtie"
 
 module MetaTagsRailsApp
   class Application < Rails::Application
-    config.secret_token = '572c86f5ede338bd8aba8dae0fd3a326aabababc98d1e6ce34b9f5'
+    config.secret_token = "572c86f5ede338bd8aba8dae0fd3a326aabababc98d1e6ce34b9f5"
     config.eager_load = false
   end
 
@@ -21,23 +21,23 @@ module MetaTagsRailsApp
     include MetaTags::ControllerHelper
 
     def index
-      @page_title       = 'title'
-      @page_keywords    = 'key1, key2, key3'
-      @page_description = 'description'
+      @page_title = "title"
+      @page_keywords = "key1, key2, key3"
+      @page_description = "description"
 
-      render plain: '_rendered_'
+      render plain: "_rendered_"
     end
 
     def show
-      render plain: '_rendered_'
+      render plain: "_rendered_"
     end
 
     def hide
-      @page_title       = nil
-      @page_keywords    = nil
+      @page_title = nil
+      @page_keywords = nil
       @page_description = nil
 
-      render plain: '_rendered_'
+      render plain: "_rendered_"
     end
 
     public :set_meta_tags, :meta_tags

--- a/spec/support/shared_examples_for_set_meta_tags.rb
+++ b/spec/support/shared_examples_for_set_meta_tags.rb
@@ -1,42 +1,42 @@
 # frozen_string_literal: true
 
-shared_examples_for '.set_meta_tags' do
-  context 'with a Hash parameter' do
-    it 'updates meta tags' do
-      subject.set_meta_tags(title: 'hello')
-      expect(subject.meta_tags[:title]).to eq('hello')
+shared_examples_for ".set_meta_tags" do
+  context "with a Hash parameter" do
+    it "updates meta tags" do
+      subject.set_meta_tags(title: "hello")
+      expect(subject.meta_tags[:title]).to eq("hello")
 
-      subject.set_meta_tags(title: 'world')
-      expect(subject.meta_tags[:title]).to eq('world')
+      subject.set_meta_tags(title: "world")
+      expect(subject.meta_tags[:title]).to eq("world")
     end
   end
 
-  context 'with an Object responding to #to_meta_tags parameter' do
-    it 'updates meta tags' do
-      object1 = double(to_meta_tags: { title: 'hello' })
-      object2 = double(to_meta_tags: { title: 'world' })
+  context "with an Object responding to #to_meta_tags parameter" do
+    it "updates meta tags" do
+      object1 = double(to_meta_tags: {title: "hello"})
+      object2 = double(to_meta_tags: {title: "world"})
 
       subject.set_meta_tags(object1)
-      expect(subject.meta_tags[:title]).to eq('hello')
+      expect(subject.meta_tags[:title]).to eq("hello")
 
       subject.set_meta_tags(object2)
-      expect(subject.meta_tags[:title]).to eq('world')
+      expect(subject.meta_tags[:title]).to eq("world")
     end
   end
 
-  it 'uses deep merge when updating meta tags' do
-    subject.set_meta_tags(og: { title: 'hello' })
-    expect(subject.meta_tags[:og]).to eq('title' => 'hello')
+  it "uses deep merge when updating meta tags" do
+    subject.set_meta_tags(og: {title: "hello"})
+    expect(subject.meta_tags[:og]).to eq("title" => "hello")
 
-    subject.set_meta_tags(og: { description: 'world' })
-    expect(subject.meta_tags[:og]).to eq('title' => 'hello', 'description' => 'world')
+    subject.set_meta_tags(og: {description: "world"})
+    expect(subject.meta_tags[:og]).to eq("title" => "hello", "description" => "world")
 
-    subject.set_meta_tags(og: { admin: { id: 1 } })
-    expect(subject.meta_tags[:og]).to eq('title' => 'hello', 'description' => 'world', 'admin' => { 'id' => 1 })
+    subject.set_meta_tags(og: {admin: {id: 1}})
+    expect(subject.meta_tags[:og]).to eq("title" => "hello", "description" => "world", "admin" => {"id" => 1})
   end
 
-  it 'normalizes :open_graph to :og' do
-    subject.set_meta_tags(open_graph: { title: 'hello' })
-    expect(subject.meta_tags[:og]).to eq('title' => 'hello')
+  it "normalizes :open_graph to :og" do
+    subject.set_meta_tags(open_graph: {title: "hello"})
+    expect(subject.meta_tags[:og]).to eq("title" => "hello")
   end
 end

--- a/spec/text_normalizer/normalize_description_spec.rb
+++ b/spec/text_normalizer/normalize_description_spec.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
-RSpec.describe MetaTags::TextNormalizer, '.normalize_description' do
-  describe 'description limit setting' do
-    let(:description) { 'd' * (MetaTags.config.description_limit + 10) }
+RSpec.describe MetaTags::TextNormalizer, ".normalize_description" do
+  describe "description limit setting" do
+    let(:description) { "d" * (MetaTags.config.description_limit + 10) }
 
-    it 'truncates description when limit is reached' do
-      expect(subject.normalize_description(description)).to eq('d' * MetaTags.config.description_limit)
+    it "truncates description when limit is reached" do
+      expect(subject.normalize_description(description)).to eq("d" * MetaTags.config.description_limit)
     end
 
-    it 'does not truncate description when limit is 0 or nil' do
+    it "does not truncate description when limit is 0 or nil" do
       MetaTags.config.description_limit = 0
       expect(subject.normalize_description(description)).to eq(description)
 

--- a/spec/text_normalizer/normalize_title_spec.rb
+++ b/spec/text_normalizer/normalize_title_spec.rb
@@ -1,125 +1,125 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
-RSpec.describe MetaTags::TextNormalizer, '.normalize_title' do
-  context 'when site_title is blank' do
-    it 'returns title when site_title is blank' do
-      expect(subject.normalize_title(nil, 'title', '-')).to eq('title')
-      expect(subject.normalize_title('', 'title', '-')).to eq('title')
+RSpec.describe MetaTags::TextNormalizer, ".normalize_title" do
+  context "when site_title is blank" do
+    it "returns title when site_title is blank" do
+      expect(subject.normalize_title(nil, "title", "-")).to eq("title")
+      expect(subject.normalize_title("", "title", "-")).to eq("title")
     end
 
-    it 'joins title parts with separator' do
-      expect(subject.normalize_title('', %w[title subtitle], '-')).to eq('title-subtitle')
+    it "joins title parts with separator" do
+      expect(subject.normalize_title("", %w[title subtitle], "-")).to eq("title-subtitle")
     end
 
-    it 'reverses title parts when reverse is true' do
-      expect(subject.normalize_title('', %w[title subtitle], '-', true)).to eq('subtitle-title')
+    it "reverses title parts when reverse is true" do
+      expect(subject.normalize_title("", %w[title subtitle], "-", true)).to eq("subtitle-title")
     end
 
-    it 'does not truncate title when limit is equal to the title length' do
-      title = 'b' * MetaTags.config.title_limit
-      expect(subject.normalize_title('', title, '-')).to eq(title)
+    it "does not truncate title when limit is equal to the title length" do
+      title = "b" * MetaTags.config.title_limit
+      expect(subject.normalize_title("", title, "-")).to eq(title)
     end
 
-    it 'truncates title when limit is reached' do
-      title = 'b' * (MetaTags.config.title_limit + 20)
-      expect(subject.normalize_title('', title, '-')).to eq('b' * MetaTags.config.title_limit)
+    it "truncates title when limit is reached" do
+      title = "b" * (MetaTags.config.title_limit + 20)
+      expect(subject.normalize_title("", title, "-")).to eq("b" * MetaTags.config.title_limit)
     end
 
-    it 'truncates last part of the title when reverse is true' do
+    it "truncates last part of the title when reverse is true" do
       title = [
-        'a' * (MetaTags.config.title_limit - 20),
-        'b' * 40,
+        "a" * (MetaTags.config.title_limit - 20),
+        "b" * 40
       ]
-      expect(subject.normalize_title('', title, '-', true)).to eq("#{'b' * 40}-#{'a' * (MetaTags.config.title_limit - 41)}")
+      expect(subject.normalize_title("", title, "-", true)).to eq("#{"b" * 40}-#{"a" * (MetaTags.config.title_limit - 41)}")
     end
   end
 
-  context 'when site_title is specified' do
-    it 'returns site when title is blank' do
-      expect(subject.normalize_title('site', nil, '-')).to eq('site')
-      expect(subject.normalize_title('site', '', '-')).to eq('site')
+  context "when site_title is specified" do
+    it "returns site when title is blank" do
+      expect(subject.normalize_title("site", nil, "-")).to eq("site")
+      expect(subject.normalize_title("site", "", "-")).to eq("site")
     end
 
-    it 'joins title and site_title with separator' do
-      expect(subject.normalize_title('site', 'title', '-')).to eq('site-title')
+    it "joins title and site_title with separator" do
+      expect(subject.normalize_title("site", "title", "-")).to eq("site-title")
     end
 
-    it 'joins title parts and site_title with separator' do
-      expect(subject.normalize_title('site', %w[title subtitle], '-')).to eq('site-title-subtitle')
+    it "joins title parts and site_title with separator" do
+      expect(subject.normalize_title("site", %w[title subtitle], "-")).to eq("site-title-subtitle")
     end
 
-    it 'reverses title parts when reverse is true' do
-      expect(subject.normalize_title('site', %w[title subtitle], '-', true)).to eq('subtitle-title-site')
+    it "reverses title parts when reverse is true" do
+      expect(subject.normalize_title("site", %w[title subtitle], "-", true)).to eq("subtitle-title-site")
     end
 
-    it 'does not add title when site title is longer than limit' do
+    it "does not add title when site title is longer than limit" do
       l = MetaTags.config.title_limit
-      site_title = 'a' * (l + 1)
-      expect(subject.normalize_title(site_title, 'title', '---')).to eq(site_title[0, l])
-      expect(subject.normalize_title(site_title[0, l - 0], 'title', '---')).to eq(site_title[0, l - 0])
-      expect(subject.normalize_title(site_title[0, l - 1], 'title', '---')).to eq(site_title[0, l - 1])
-      expect(subject.normalize_title(site_title[0, l - 2], 'title', '---')).to eq(site_title[0, l - 2])
-      expect(subject.normalize_title(site_title[0, l - 3], 'title', '---')).to eq(site_title[0, l - 3])
-      expect(subject.normalize_title(site_title[0, l - 4], 'title', '---')).to eq("#{site_title[0, l - 4]}---t")
+      site_title = "a" * (l + 1)
+      expect(subject.normalize_title(site_title, "title", "---")).to eq(site_title[0, l])
+      expect(subject.normalize_title(site_title[0, l - 0], "title", "---")).to eq(site_title[0, l - 0])
+      expect(subject.normalize_title(site_title[0, l - 1], "title", "---")).to eq(site_title[0, l - 1])
+      expect(subject.normalize_title(site_title[0, l - 2], "title", "---")).to eq(site_title[0, l - 2])
+      expect(subject.normalize_title(site_title[0, l - 3], "title", "---")).to eq(site_title[0, l - 3])
+      expect(subject.normalize_title(site_title[0, l - 4], "title", "---")).to eq("#{site_title[0, l - 4]}---t")
     end
 
-    it 'truncates title when limit is reached' do
-      site_title = 'a' * 20
-      title = 'b' * (MetaTags.config.title_limit + 10)
-      expect(subject.normalize_title(site_title, title, '-')).to eq("#{site_title}-#{'b' * (MetaTags.config.title_limit - 21)}")
+    it "truncates title when limit is reached" do
+      site_title = "a" * 20
+      title = "b" * (MetaTags.config.title_limit + 10)
+      expect(subject.normalize_title(site_title, title, "-")).to eq("#{site_title}-#{"b" * (MetaTags.config.title_limit - 21)}")
     end
 
-    it 'does not truncate title when title_limit is 0 or nil' do
-      site_title = 'a' * 20
-      title = 'b' * (MetaTags.config.title_limit + 10)
+    it "does not truncate title when title_limit is 0 or nil" do
+      site_title = "a" * 20
+      title = "b" * (MetaTags.config.title_limit + 10)
 
       MetaTags.config.title_limit = 0
-      expect(subject.normalize_title(site_title, title, '-')).to eq("#{site_title}-#{title}")
+      expect(subject.normalize_title(site_title, title, "-")).to eq("#{site_title}-#{title}")
 
       MetaTags.config.title_limit = nil
-      expect(subject.normalize_title(site_title, title, '-')).to eq("#{site_title}-#{title}")
+      expect(subject.normalize_title(site_title, title, "-")).to eq("#{site_title}-#{title}")
     end
 
-    it 'truncates title when limit is reached on unescaped value' do
-      site_title = 'a' * 20
+    it "truncates title when limit is reached on unescaped value" do
+      site_title = "a" * 20
       title = '"' * (MetaTags.config.title_limit + 10)
-      expect(subject.normalize_title(site_title, title, '-')).to eq("#{site_title}-#{'&quot;' * (MetaTags.config.title_limit - 21)}")
+      expect(subject.normalize_title(site_title, title, "-")).to eq("#{site_title}-#{"&quot;" * (MetaTags.config.title_limit - 21)}")
     end
   end
 
-  context 'when truncate_site_title_first is true' do
+  context "when truncate_site_title_first is true" do
     before do
       MetaTags.config.truncate_site_title_first = true
     end
 
-    it 'does not add site title when title is longer than limit' do
+    it "does not add site title when title is longer than limit" do
       l = MetaTags.config.title_limit
-      title = 'a' * (l + 1)
-      expect(subject.normalize_title('site', title, '---')).to eq(title[0, l])
-      expect(subject.normalize_title('site', title[0, l - 0], '---')).to eq(title[0, l - 0])
-      expect(subject.normalize_title('site', title[0, l - 1], '---')).to eq(title[0, l - 1])
-      expect(subject.normalize_title('site', title[0, l - 2], '---')).to eq(title[0, l - 2])
-      expect(subject.normalize_title('site', title[0, l - 3], '---')).to eq(title[0, l - 3])
-      expect(subject.normalize_title('site', title[0, l - 4], '---')).to eq("s---#{title[0, l - 4]}")
+      title = "a" * (l + 1)
+      expect(subject.normalize_title("site", title, "---")).to eq(title[0, l])
+      expect(subject.normalize_title("site", title[0, l - 0], "---")).to eq(title[0, l - 0])
+      expect(subject.normalize_title("site", title[0, l - 1], "---")).to eq(title[0, l - 1])
+      expect(subject.normalize_title("site", title[0, l - 2], "---")).to eq(title[0, l - 2])
+      expect(subject.normalize_title("site", title[0, l - 3], "---")).to eq(title[0, l - 3])
+      expect(subject.normalize_title("site", title[0, l - 4], "---")).to eq("s---#{title[0, l - 4]}")
     end
 
-    it 'truncates site title when limit is reached' do
-      site_title = 'a' * (MetaTags.config.title_limit + 10)
-      title = 'b' * 20
-      expect(subject.normalize_title(site_title, title, '-')).to eq("#{'a' * (MetaTags.config.title_limit - 21)}-#{title}")
+    it "truncates site title when limit is reached" do
+      site_title = "a" * (MetaTags.config.title_limit + 10)
+      title = "b" * 20
+      expect(subject.normalize_title(site_title, title, "-")).to eq("#{"a" * (MetaTags.config.title_limit - 21)}-#{title}")
     end
 
-    it 'does not truncate site title when title_limit is 0 or nil' do
-      site_title = 'a' * (MetaTags.config.title_limit + 10)
-      title = 'b' * 20
+    it "does not truncate site title when title_limit is 0 or nil" do
+      site_title = "a" * (MetaTags.config.title_limit + 10)
+      title = "b" * 20
 
       MetaTags.config.title_limit = 0
-      expect(subject.normalize_title(site_title, title, '-')).to eq("#{site_title}-#{title}")
+      expect(subject.normalize_title(site_title, title, "-")).to eq("#{site_title}-#{title}")
 
       MetaTags.config.title_limit = nil
-      expect(subject.normalize_title(site_title, title, '-')).to eq("#{site_title}-#{title}")
+      expect(subject.normalize_title(site_title, title, "-")).to eq("#{site_title}-#{title}")
     end
   end
 end

--- a/spec/text_normalizer/truncate_array_spec.rb
+++ b/spec/text_normalizer/truncate_array_spec.rb
@@ -1,62 +1,62 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
-RSpec.describe MetaTags::TextNormalizer, '.truncate_array' do
-  it 'returns array as is when limit is not specified' do
+RSpec.describe MetaTags::TextNormalizer, ".truncate_array" do
+  it "returns array as is when limit is not specified" do
     arr = %w[a]
     expect(subject.truncate_array(arr, nil)).to be(arr)
     expect(subject.truncate_array(arr, 0)).to be(arr)
   end
 
-  it 'returns a new array when limit is specified' do
+  it "returns a new array when limit is specified" do
     arr = %w[a]
     expect(subject.truncate_array(arr, 1)).not_to be(arr)
   end
 
-  context 'when separator is empty string' do
-    it 'returns the whole array when total size is less than or equal to limit' do
+  context "when separator is empty string" do
+    it "returns the whole array when total size is less than or equal to limit" do
       arr = %w[a a]
       expect(subject.truncate_array(arr, 5)).to eq(arr)
       expect(subject.truncate_array(arr, 2)).to eq(arr)
     end
 
-    it 'truncates array to specified limit' do
+    it "truncates array to specified limit" do
       arr = %w[a a a a a]
       expect(subject.truncate_array(arr, 3)).to eq(%w[a a a])
     end
 
-    it 'truncates last word to match the limit' do
+    it "truncates last word to match the limit" do
       arr = %w[a a aaaa aa]
       expect(subject.truncate_array(arr, 4)).to eq(%w[a a aa])
     end
 
-    it 'uses natural separator when truncating a long word' do
-      arr = ['a', 'aa aaaa', 'aa']
+    it "uses natural separator when truncating a long word" do
+      arr = ["a", "aa aaaa", "aa"]
       expect(subject.truncate_array(arr, 7)).to eq(%w[a aa])
     end
   end
 
-  context 'when separator is specified' do
-    it 'returns the whole array when total size is less than or equal to limit' do
+  context "when separator is specified" do
+    it "returns the whole array when total size is less than or equal to limit" do
       arr = %w[a a]
-      expect(subject.truncate_array(arr, 5, '-')).to eq(arr)
-      expect(subject.truncate_array(arr, 3, '-')).to eq(arr)
+      expect(subject.truncate_array(arr, 5, "-")).to eq(arr)
+      expect(subject.truncate_array(arr, 3, "-")).to eq(arr)
     end
 
-    it 'truncates array to specified limit' do
+    it "truncates array to specified limit" do
       arr = %w[a a a a a]
-      expect(subject.truncate_array(arr, 3, '-')).to eq(%w[a a])
+      expect(subject.truncate_array(arr, 3, "-")).to eq(%w[a a])
     end
 
-    it 'truncates last word to match the limit' do
+    it "truncates last word to match the limit" do
       arr = %w[a a aaaa aa]
-      expect(subject.truncate_array(arr, 5, '-')).to eq(%w[a a a])
+      expect(subject.truncate_array(arr, 5, "-")).to eq(%w[a a a])
     end
 
-    it 'uses natural separator when truncating a long word' do
-      arr = ['a', 'aa aaaa', 'aa']
-      expect(subject.truncate_array(arr, 7, '-')).to eq(%w[a aa])
+    it "uses natural separator when truncating a long word" do
+      arr = ["a", "aa aaaa", "aa"]
+      expect(subject.truncate_array(arr, 7, "-")).to eq(%w[a aa])
     end
   end
 end

--- a/spec/view_helper/article_spec.rb
+++ b/spec/view_helper/article_spec.rb
@@ -4,30 +4,30 @@ require "spec_helper"
 
 RSpec.describe MetaTags::ViewHelper, "displaying Article meta tags" do
   it "displays meta tags specified with :article" do
-    subject.set_meta_tags(article: { author: "https://www.facebook.com/facebook" })
+    subject.set_meta_tags(article: {author: "https://www.facebook.com/facebook"})
     subject.display_meta_tags(site: "someSite").tap do |meta|
-      expect(meta).to have_tag("meta", with: { content: "https://www.facebook.com/facebook", property: "article:author" })
+      expect(meta).to have_tag("meta", with: {content: "https://www.facebook.com/facebook", property: "article:author"})
     end
   end
 
   it "uses deep merge when displaying open graph meta tags" do
-    subject.set_meta_tags(article: { author: "https://www.facebook.com/facebook" })
-    subject.display_meta_tags(article: { publisher: "https://www.facebook.com/Google/" }).tap do |meta|
-      expect(meta).to have_tag("meta", with: { content: "https://www.facebook.com/facebook", property: "article:author" })
-      expect(meta).to have_tag("meta", with: { content: "https://www.facebook.com/Google/", property: "article:publisher" })
+    subject.set_meta_tags(article: {author: "https://www.facebook.com/facebook"})
+    subject.display_meta_tags(article: {publisher: "https://www.facebook.com/Google/"}).tap do |meta|
+      expect(meta).to have_tag("meta", with: {content: "https://www.facebook.com/facebook", property: "article:author"})
+      expect(meta).to have_tag("meta", with: {content: "https://www.facebook.com/Google/", property: "article:publisher"})
     end
   end
 
   it "does not display meta tags without content" do
     subject.set_meta_tags(
       article: {
-        author:    "",
-        publisher: "",
-      },
+        author: "",
+        publisher: ""
+      }
     )
     subject.display_meta_tags(site: "someSite").tap do |meta|
-      expect(meta).not_to have_tag("meta", with: { content: "", property: "article:author" })
-      expect(meta).not_to have_tag("meta", with: { content: "", property: "article:publisher" })
+      expect(meta).not_to have_tag("meta", with: {content: "", property: "article:author"})
+      expect(meta).not_to have_tag("meta", with: {content: "", property: "article:publisher"})
     end
   end
 end

--- a/spec/view_helper/charset_spec.rb
+++ b/spec/view_helper/charset_spec.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
-RSpec.describe MetaTags::ViewHelper, 'displaying charset' do
-  it 'does not display charset if blank' do
-    expect(subject.display_meta_tags).to eq('')
-    expect(subject.display_meta_tags(charset: '')).to eq('')
+RSpec.describe MetaTags::ViewHelper, "displaying charset" do
+  it "does not display charset if blank" do
+    expect(subject.display_meta_tags).to eq("")
+    expect(subject.display_meta_tags(charset: "")).to eq("")
   end
 
-  it 'displays charset' do
-    subject.display_meta_tags(charset: 'UTF-8').tap do |meta|
+  it "displays charset" do
+    subject.display_meta_tags(charset: "UTF-8").tap do |meta|
       expect(meta).to eq('<meta charset="UTF-8">')
     end
   end

--- a/spec/view_helper/custom_spec.rb
+++ b/spec/view_helper/custom_spec.rb
@@ -1,93 +1,93 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe MetaTags::ViewHelper do
-  describe 'display any named meta tag that you want to' do
-    it 'displays testing meta tag' do
-      subject.display_meta_tags(testing: 'this is a test').tap do |meta|
-        expect(meta).to have_tag('meta', with: { content: "this is a test", name: "testing" })
+  describe "display any named meta tag that you want to" do
+    it "displays testing meta tag" do
+      subject.display_meta_tags(testing: "this is a test").tap do |meta|
+        expect(meta).to have_tag("meta", with: {content: "this is a test", name: "testing"})
       end
     end
 
-    it 'supports Array values' do
-      subject.display_meta_tags(testing: ['test1', 'test2']).tap do |meta|
-        expect(meta).to have_tag('meta', with: { content: "test1", name: "testing" })
-        expect(meta).to have_tag('meta', with: { content: "test2", name: "testing" })
+    it "supports Array values" do
+      subject.display_meta_tags(testing: ["test1", "test2"]).tap do |meta|
+        expect(meta).to have_tag("meta", with: {content: "test1", name: "testing"})
+        expect(meta).to have_tag("meta", with: {content: "test2", name: "testing"})
       end
     end
 
-    it 'supports Hash values' do
-      subject.display_meta_tags(testing: { tag: 'value' }).tap do |meta|
-        expect(meta).to have_tag('meta', with: { content: "value", name: "testing:tag" })
+    it "supports Hash values" do
+      subject.display_meta_tags(testing: {tag: "value"}).tap do |meta|
+        expect(meta).to have_tag("meta", with: {content: "value", name: "testing:tag"})
       end
     end
 
-    it 'supports symbolic references in Hash values' do
-      subject.display_meta_tags(title: 'my title', testing: { tag: :title }).tap do |meta|
-        expect(meta).to have_tag('meta', with: { content: "my title", name: "testing:tag" })
+    it "supports symbolic references in Hash values" do
+      subject.display_meta_tags(title: "my title", testing: {tag: :title}).tap do |meta|
+        expect(meta).to have_tag("meta", with: {content: "my title", name: "testing:tag"})
       end
     end
 
-    it 'does not render when value is nil' do
+    it "does not render when value is nil" do
       subject.display_meta_tags(testing: nil).tap do |meta|
-        expect(meta).to eq('')
+        expect(meta).to eq("")
       end
     end
 
-    it 'allows to specify itemprop' do
+    it "allows to specify itemprop" do
       subject.set_meta_tags(
         og: {
           image: {
-            _:        'image.png',
-            type:     'image/jpeg',
-            width:    200,
-            height:   {
-              _:        200,
-              itemprop: 'custom',
+            _: "image.png",
+            type: "image/jpeg",
+            width: 200,
+            height: {
+              _: 200,
+              itemprop: "custom"
             },
-            itemprop: 'image',
-          },
-        },
+            itemprop: "image"
+          }
+        }
       )
 
       meta = subject.display_meta_tags
-      aggregate_failures 'meta tags' do
-        expect(meta).to have_tag('meta', with: { property: "og:image", content: "image.png", itemprop: "image" })
-        expect(meta).to have_tag('meta', with: { property: "og:image:type", content: "image/jpeg" }, without: { itemprop: "image" })
-        expect(meta).to have_tag('meta', with: { property: "og:image:width", content: "200" }, without: { itemprop: "image" })
-        expect(meta).to have_tag('meta', with: { property: "og:image:height", content: "200", itemprop: "custom" })
-        expect(meta).not_to have_tag('meta', with: { property: "og:image:itemprop" })
+      aggregate_failures "meta tags" do
+        expect(meta).to have_tag("meta", with: {property: "og:image", content: "image.png", itemprop: "image"})
+        expect(meta).to have_tag("meta", with: {property: "og:image:type", content: "image/jpeg"}, without: {itemprop: "image"})
+        expect(meta).to have_tag("meta", with: {property: "og:image:width", content: "200"}, without: {itemprop: "image"})
+        expect(meta).to have_tag("meta", with: {property: "og:image:height", content: "200", itemprop: "custom"})
+        expect(meta).not_to have_tag("meta", with: {property: "og:image:itemprop"})
       end
     end
 
-    it 'displays meta tags with hashes and arrays' do
+    it "displays meta tags with hashes and arrays" do
       test_hashes_and_arrays
     end
 
-    it 'uses `property` attribute instead of `name` for custom tags listed under `property_tags` in config' do
-      MetaTags.config.property_tags.push(:testing1, 'testing2', 'namespace:')
+    it "uses `property` attribute instead of `name` for custom tags listed under `property_tags` in config" do
+      MetaTags.config.property_tags.push(:testing1, "testing2", "namespace:")
 
-      subject.display_meta_tags('testing1' => 'test').tap do |meta|
-        expect(meta).to have_tag('meta', with: { content: "test", property: "testing1" })
+      subject.display_meta_tags("testing1" => "test").tap do |meta|
+        expect(meta).to have_tag("meta", with: {content: "test", property: "testing1"})
       end
 
-      subject.display_meta_tags('testing2:nested' => 'nested test').tap do |meta|
-        expect(meta).to have_tag('meta', with: { content: "nested test", property: "testing2:nested" })
+      subject.display_meta_tags("testing2:nested" => "nested test").tap do |meta|
+        expect(meta).to have_tag("meta", with: {content: "nested test", property: "testing2:nested"})
       end
 
-      subject.display_meta_tags('namespace:thing' => 'namespace test').tap do |meta|
-        expect(meta).to have_tag('meta', with: { content: "namespace test", property: "namespace:thing" })
+      subject.display_meta_tags("namespace:thing" => "namespace test").tap do |meta|
+        expect(meta).to have_tag("meta", with: {content: "namespace test", property: "namespace:thing"})
       end
     end
 
-    it 'displays `property_tags` in hashes and arrays properly' do
+    it "displays `property_tags` in hashes and arrays properly" do
       MetaTags.config.property_tags.push(:foo)
 
       test_hashes_and_arrays(name_key: :property)
     end
 
-    it 'does not use `property` tag for the keys that do not match `property_tags`' do
+    it "does not use `property` tag for the keys that do not match `property_tags`" do
       MetaTags.config.property_tags.push(:foos)
       MetaTags.config.property_tags.push(:fo)
 
@@ -95,35 +95,35 @@ RSpec.describe MetaTags::ViewHelper do
     end
   end
 
-  def test_hashes_and_arrays(name_key: :name) # rubocop:disable Metrics/AbcSize
+  def test_hashes_and_arrays(name_key: :name)
     subject.set_meta_tags(
       foo: {
-        _:    "test",
-        bar:  "lorem",
-        baz:  {
-          qux: ["lorem", "ipsum"],
+        _: "test",
+        bar: "lorem",
+        baz: {
+          qux: ["lorem", "ipsum"]
         },
         quux: [
           {
-            corge:  "lorem",
-            grault: "ipsum",
+            corge: "lorem",
+            grault: "ipsum"
           },
           {
-            corge:  "dolor",
-            grault: "sit",
-          },
-        ],
-      },
+            corge: "dolor",
+            grault: "sit"
+          }
+        ]
+      }
     )
-    subject.display_meta_tags(site: 'someSite').tap do |meta|
-      expect(meta).to have_tag('meta', with: { content: "lorem", name_key => "foo:bar" })
-      expect(meta).to have_tag('meta', with: { content: "lorem", name_key => "foo:baz:qux" })
-      expect(meta).to have_tag('meta', with: { content: "ipsum", name_key => "foo:baz:qux" })
-      expect(meta).to have_tag('meta', with: { content: "lorem", name_key => "foo:quux:corge" })
-      expect(meta).to have_tag('meta', with: { content: "ipsum", name_key => "foo:quux:grault" })
-      expect(meta).to have_tag('meta', with: { content: "dolor", name_key => "foo:quux:corge" })
-      expect(meta).to have_tag('meta', with: { content: "sit", name_key => "foo:quux:grault" })
-      expect(meta).not_to have_tag('meta', with: { name: "foo:quux" })
+    subject.display_meta_tags(site: "someSite").tap do |meta|
+      expect(meta).to have_tag("meta", with: {:content => "lorem", name_key => "foo:bar"})
+      expect(meta).to have_tag("meta", with: {:content => "lorem", name_key => "foo:baz:qux"})
+      expect(meta).to have_tag("meta", with: {:content => "ipsum", name_key => "foo:baz:qux"})
+      expect(meta).to have_tag("meta", with: {:content => "lorem", name_key => "foo:quux:corge"})
+      expect(meta).to have_tag("meta", with: {:content => "ipsum", name_key => "foo:quux:grault"})
+      expect(meta).to have_tag("meta", with: {:content => "dolor", name_key => "foo:quux:corge"})
+      expect(meta).to have_tag("meta", with: {:content => "sit", name_key => "foo:quux:grault"})
+      expect(meta).not_to have_tag("meta", with: {name: "foo:quux"})
     end
   end
 end

--- a/spec/view_helper/description_spec.rb
+++ b/spec/view_helper/description_spec.rb
@@ -1,95 +1,95 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
-RSpec.describe MetaTags::ViewHelper, 'displaying description' do
-  it 'does not display description if blank' do
-    subject.description('')
-    expect(subject.display_meta_tags).to eq('')
+RSpec.describe MetaTags::ViewHelper, "displaying description" do
+  it "does not display description if blank" do
+    subject.description("")
+    expect(subject.display_meta_tags).to eq("")
   end
 
   it 'displays description when "description" used' do
-    subject.description('someDescription')
-    subject.display_meta_tags(site: 'someSite').tap do |meta|
-      expect(meta).to have_tag('meta', with: { content: "someDescription", name: "description" })
+    subject.description("someDescription")
+    subject.display_meta_tags(site: "someSite").tap do |meta|
+      expect(meta).to have_tag("meta", with: {content: "someDescription", name: "description"})
     end
   end
 
   it 'displays description when "set_meta_tags" used' do
-    subject.set_meta_tags(description: 'someDescription')
-    subject.display_meta_tags(site: 'someSite').tap do |meta|
-      expect(meta).to have_tag('meta', with: { content: "someDescription", name: "description" })
+    subject.set_meta_tags(description: "someDescription")
+    subject.display_meta_tags(site: "someSite").tap do |meta|
+      expect(meta).to have_tag("meta", with: {content: "someDescription", name: "description"})
     end
   end
 
-  it 'displays default description' do
-    subject.display_meta_tags(site: 'someSite', description: 'someDescription').tap do |meta|
-      expect(meta).to have_tag('meta', with: { content: "someDescription", name: "description" })
+  it "displays default description" do
+    subject.display_meta_tags(site: "someSite", description: "someDescription").tap do |meta|
+      expect(meta).to have_tag("meta", with: {content: "someDescription", name: "description"})
     end
   end
 
-  it 'uses custom description if given' do
-    subject.description('someDescription')
-    subject.display_meta_tags(site: 'someSite', description: 'defaultDescription').tap do |meta|
-      expect(meta).to have_tag('meta', with: { content: "someDescription", name: "description" })
+  it "uses custom description if given" do
+    subject.description("someDescription")
+    subject.display_meta_tags(site: "someSite", description: "defaultDescription").tap do |meta|
+      expect(meta).to have_tag("meta", with: {content: "someDescription", name: "description"})
     end
   end
 
-  it 'strips multiple spaces' do
-    subject.display_meta_tags(site: 'someSite', description: "some \n\r\t description").tap do |meta|
-      expect(meta).to have_tag('meta', with: { content: "some description", name: "description" })
+  it "strips multiple spaces" do
+    subject.display_meta_tags(site: "someSite", description: "some \n\r\t description").tap do |meta|
+      expect(meta).to have_tag("meta", with: {content: "some description", name: "description"})
     end
   end
 
-  it 'strips HTML' do
-    subject.display_meta_tags(site: 'someSite', description: "<p>some <b>description</b></p>").tap do |meta|
-      expect(meta).to have_tag('meta', with: { content: "some description", name: "description" })
+  it "strips HTML" do
+    subject.display_meta_tags(site: "someSite", description: "<p>some <b>description</b></p>").tap do |meta|
+      expect(meta).to have_tag("meta", with: {content: "some description", name: "description"})
     end
   end
 
-  it 'escapes double quotes' do
+  it "escapes double quotes" do
     subject.display_meta_tags(description: 'some "description"').tap do |meta|
-      expect(meta).to have_tag('meta', with: { content: "some \"description\"", name: "description" })
+      expect(meta).to have_tag("meta", with: {content: "some \"description\"", name: "description"})
     end
   end
 
-  it 'escapes ampersands properly' do
-    subject.display_meta_tags(description: 'verify & commit').tap do |meta|
-      expect(meta).to have_tag('meta', with: { content: "verify & commit", name: "description" })
+  it "escapes ampersands properly" do
+    subject.display_meta_tags(description: "verify & commit").tap do |meta|
+      expect(meta).to have_tag("meta", with: {content: "verify & commit", name: "description"})
     end
   end
 
-  it 'truncates correctly' do
-    subject.display_meta_tags(site: 'someSite', description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam dolor lorem, lobortis quis faucibus id, tristique at lorem. Nullam sit amet mollis libero. Morbi ut sem malesuada massa faucibus vestibulum non sed quam. Duis quis consectetur lacus. Donec vitae nunc risus. Sed placerat semper elit, sit amet tristique dolor. Maecenas hendrerit volutpat.").tap do |meta|
-      expect(meta).to have_tag('meta', with: { content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam dolor lorem, lobortis quis faucibus id, tristique at lorem. Nullam sit amet mollis libero. Morbi ut sem malesuada massa faucibus vestibulum non sed quam. Duis quis consectetur lacus. Donec vitae nunc risus. Sed placerat semper elit, sit", name: "description" })
+  it "truncates correctly" do
+    subject.display_meta_tags(site: "someSite", description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam dolor lorem, lobortis quis faucibus id, tristique at lorem. Nullam sit amet mollis libero. Morbi ut sem malesuada massa faucibus vestibulum non sed quam. Duis quis consectetur lacus. Donec vitae nunc risus. Sed placerat semper elit, sit amet tristique dolor. Maecenas hendrerit volutpat.").tap do |meta|
+      expect(meta).to have_tag("meta", with: {content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam dolor lorem, lobortis quis faucibus id, tristique at lorem. Nullam sit amet mollis libero. Morbi ut sem malesuada massa faucibus vestibulum non sed quam. Duis quis consectetur lacus. Donec vitae nunc risus. Sed placerat semper elit, sit", name: "description"})
     end
   end
 
-  it 'treats nil as an empty string' do
+  it "treats nil as an empty string" do
     subject.display_meta_tags(description: nil).tap do |meta|
-      expect(meta).not_to have_tag('meta', with: { name: "description" })
+      expect(meta).not_to have_tag("meta", with: {name: "description"})
     end
   end
 
-  it 'allows objects that respond to #to_str' do
-    description = double(to_str: 'some description')
+  it "allows objects that respond to #to_str" do
+    description = double(to_str: "some description")
     subject.display_meta_tags(description: description).tap do |meta|
-      expect(meta).to have_tag('meta', with: { content: "some description", name: "description" })
+      expect(meta).to have_tag("meta", with: {content: "some description", name: "description"})
     end
   end
 
-  it 'works with frozen strings' do
+  it "works with frozen strings" do
     allow(MetaTags::TextNormalizer).to receive(:strip_tags) { |s| s }
     subject.display_meta_tags(description: "some description").tap do |meta|
-      expect(meta).to have_tag('meta', with: { content: "some description", name: "description" })
+      expect(meta).to have_tag("meta", with: {content: "some description", name: "description"})
     end
   end
 
-  it 'fails when title is not a String-like object' do
+  it "fails when title is not a String-like object" do
     skip("Fails RBS") if ENV["RBS_TEST_TARGET"] # rubocop:disable RSpec/Pending
 
     expect {
       subject.display_meta_tags(description: 5)
-    }.to raise_error ArgumentError, 'Expected a string or an object that implements #to_str'
+    }.to raise_error ArgumentError, "Expected a string or an object that implements #to_str"
   end
 end

--- a/spec/view_helper/icon_spec.rb
+++ b/spec/view_helper/icon_spec.rb
@@ -1,44 +1,44 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe MetaTags::ViewHelper do
-  it 'does not display icon by default' do
-    subject.display_meta_tags(site: 'someSite').tap do |meta|
-      expect(meta).not_to have_tag('link', with: { rel: 'icon' })
+  it "does not display icon by default" do
+    subject.display_meta_tags(site: "someSite").tap do |meta|
+      expect(meta).not_to have_tag("link", with: {rel: "icon"})
     end
   end
 
   it 'displays icon when "set_meta_tags" used' do
-    subject.set_meta_tags(icon: '/favicon.ico')
-    subject.display_meta_tags(site: 'someSite').tap do |meta|
-      expect(meta).to have_tag('link', with: { href: '/favicon.ico', rel: 'icon', type: 'image/x-icon' })
+    subject.set_meta_tags(icon: "/favicon.ico")
+    subject.display_meta_tags(site: "someSite").tap do |meta|
+      expect(meta).to have_tag("link", with: {href: "/favicon.ico", rel: "icon", type: "image/x-icon"})
     end
   end
 
-  it 'displays default canonical url' do
-    subject.display_meta_tags(site: 'someSite', icon: '/favicon.ico').tap do |meta|
-      expect(meta).to have_tag('link', with: { href: '/favicon.ico', rel: 'icon', type: 'image/x-icon' })
+  it "displays default canonical url" do
+    subject.display_meta_tags(site: "someSite", icon: "/favicon.ico").tap do |meta|
+      expect(meta).to have_tag("link", with: {href: "/favicon.ico", rel: "icon", type: "image/x-icon"})
     end
   end
 
-  it 'allows to specify hash as an icon' do
-    subject.set_meta_tags(icon: { href: '/favicon.png', type: 'image/png' })
-    subject.display_meta_tags(site: 'someSite').tap do |meta|
-      expect(meta).to have_tag('link', with: { href: '/favicon.png', rel: 'icon', type: 'image/png' })
+  it "allows to specify hash as an icon" do
+    subject.set_meta_tags(icon: {href: "/favicon.png", type: "image/png"})
+    subject.display_meta_tags(site: "someSite").tap do |meta|
+      expect(meta).to have_tag("link", with: {href: "/favicon.png", rel: "icon", type: "image/png"})
     end
   end
 
-  it 'allows to specify multiple icons' do
+  it "allows to specify multiple icons" do
     subject.set_meta_tags(
       icon: [
-        { href: '/images/icons/icon_96.png', sizes: '32x32 96x96', type: 'image/png' },
-        { href: '/images/icons/icon_itouch_precomp_32.png', rel: 'apple-touch-icon-precomposed', sizes: '32x32', type: 'image/png' },
-      ],
+        {href: "/images/icons/icon_96.png", sizes: "32x32 96x96", type: "image/png"},
+        {href: "/images/icons/icon_itouch_precomp_32.png", rel: "apple-touch-icon-precomposed", sizes: "32x32", type: "image/png"}
+      ]
     )
-    subject.display_meta_tags(site: 'someSite').tap do |meta|
-      expect(meta).to have_tag('link', with: { href: '/images/icons/icon_96.png', rel: 'icon', type: 'image/png', sizes: '32x32 96x96' })
-      expect(meta).to have_tag('link', with: { href: '/images/icons/icon_itouch_precomp_32.png', rel: 'apple-touch-icon-precomposed', type: 'image/png', sizes: '32x32' })
+    subject.display_meta_tags(site: "someSite").tap do |meta|
+      expect(meta).to have_tag("link", with: {href: "/images/icons/icon_96.png", rel: "icon", type: "image/png", sizes: "32x32 96x96"})
+      expect(meta).to have_tag("link", with: {href: "/images/icons/icon_itouch_precomp_32.png", rel: "apple-touch-icon-precomposed", type: "image/png", sizes: "32x32"})
     end
   end
 end

--- a/spec/view_helper/keywords_spec.rb
+++ b/spec/view_helper/keywords_spec.rb
@@ -1,68 +1,68 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
-RSpec.describe MetaTags::ViewHelper, 'displaying keywords' do
-  it 'does not display keywords if blank' do
-    subject.keywords('')
-    expect(subject.display_meta_tags).to eq('')
+RSpec.describe MetaTags::ViewHelper, "displaying keywords" do
+  it "does not display keywords if blank" do
+    subject.keywords("")
+    expect(subject.display_meta_tags).to eq("")
 
     subject.keywords([])
-    expect(subject.display_meta_tags).to eq('')
+    expect(subject.display_meta_tags).to eq("")
   end
 
   it 'displays keywords when "keywords" used' do
-    subject.keywords('some-keywords')
-    subject.display_meta_tags(site: 'someSite').tap do |meta|
-      expect(meta).to have_tag('meta', with: { content: "some-keywords", name: "keywords" })
+    subject.keywords("some-keywords")
+    subject.display_meta_tags(site: "someSite").tap do |meta|
+      expect(meta).to have_tag("meta", with: {content: "some-keywords", name: "keywords"})
     end
   end
 
   it 'displays keywords when "set_meta_tags" used' do
-    subject.set_meta_tags(keywords: 'some-keywords')
-    subject.display_meta_tags(site: 'someSite').tap do |meta|
-      expect(meta).to have_tag('meta', with: { content: "some-keywords", name: "keywords" })
+    subject.set_meta_tags(keywords: "some-keywords")
+    subject.display_meta_tags(site: "someSite").tap do |meta|
+      expect(meta).to have_tag("meta", with: {content: "some-keywords", name: "keywords"})
     end
   end
 
-  it 'displays default keywords' do
-    subject.display_meta_tags(site: 'someSite', keywords: 'some-keywords').tap do |meta|
-      expect(meta).to have_tag('meta', with: { content: "some-keywords", name: "keywords" })
+  it "displays default keywords" do
+    subject.display_meta_tags(site: "someSite", keywords: "some-keywords").tap do |meta|
+      expect(meta).to have_tag("meta", with: {content: "some-keywords", name: "keywords"})
     end
   end
 
-  it 'uses custom keywords if given' do
-    subject.keywords('some-keywords')
-    subject.display_meta_tags(site: 'someSite', keywords: 'default_keywords').tap do |meta|
-      expect(meta).to have_tag('meta', with: { content: "some-keywords", name: "keywords" })
+  it "uses custom keywords if given" do
+    subject.keywords("some-keywords")
+    subject.display_meta_tags(site: "someSite", keywords: "default_keywords").tap do |meta|
+      expect(meta).to have_tag("meta", with: {content: "some-keywords", name: "keywords"})
     end
   end
 
-  it 'joins keywords from Array' do
-    subject.display_meta_tags(site: 'someSite', keywords: %w[keyword1 keyword2]).tap do |meta|
-      expect(meta).to have_tag('meta', with: { content: "keyword1, keyword2", name: "keywords" })
+  it "joins keywords from Array" do
+    subject.display_meta_tags(site: "someSite", keywords: %w[keyword1 keyword2]).tap do |meta|
+      expect(meta).to have_tag("meta", with: {content: "keyword1, keyword2", name: "keywords"})
     end
   end
 
-  it 'joins keywords from nested Arrays' do
-    subject.display_meta_tags(site: 'someSite', keywords: [%w[keyword1 keyword2], 'keyword3']).tap do |meta|
-      expect(meta).to have_tag('meta', with: { content: "keyword1, keyword2, keyword3", name: "keywords" })
+  it "joins keywords from nested Arrays" do
+    subject.display_meta_tags(site: "someSite", keywords: [%w[keyword1 keyword2], "keyword3"]).tap do |meta|
+      expect(meta).to have_tag("meta", with: {content: "keyword1, keyword2, keyword3", name: "keywords"})
     end
   end
 
-  context 'with the default configuration' do
-    it 'lowercases keywords' do
-      subject.display_meta_tags(site: 'someSite', keywords: 'someKeywords').tap do |meta|
-        expect(meta).to have_tag('meta', with: { content: 'somekeywords', name: 'keywords' })
+  context "with the default configuration" do
+    it "lowercases keywords" do
+      subject.display_meta_tags(site: "someSite", keywords: "someKeywords").tap do |meta|
+        expect(meta).to have_tag("meta", with: {content: "somekeywords", name: "keywords"})
       end
     end
   end
 
-  context 'when `keywords_lowercase` is false' do
-    it 'does not lowercase keywords' do
+  context "when `keywords_lowercase` is false" do
+    it "does not lowercase keywords" do
       MetaTags.config.keywords_lowercase = false
-      subject.display_meta_tags(site: 'someSite', keywords: 'someKeywords').tap do |meta|
-        expect(meta).to have_tag('meta', with: { content: 'someKeywords', name: 'keywords' })
+      subject.display_meta_tags(site: "someSite", keywords: "someKeywords").tap do |meta|
+        expect(meta).to have_tag("meta", with: {content: "someKeywords", name: "keywords"})
       end
     end
   end

--- a/spec/view_helper/links_spec.rb
+++ b/spec/view_helper/links_spec.rb
@@ -1,36 +1,36 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe MetaTags::ViewHelper do
-  describe 'displaying canonical url' do
-    it 'does not display canonical url by default' do
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).not_to have_tag('link', with: { href: "http://example.com/base/url", rel: "canonical" })
+  describe "displaying canonical url" do
+    it "does not display canonical url by default" do
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).not_to have_tag("link", with: {href: "http://example.com/base/url", rel: "canonical"})
       end
     end
 
     it 'displays canonical url when "set_meta_tags" used' do
-      subject.set_meta_tags(canonical: 'http://example.com/base/url')
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).to have_tag('link', with: { href: "http://example.com/base/url", rel: "canonical" })
+      subject.set_meta_tags(canonical: "http://example.com/base/url")
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).to have_tag("link", with: {href: "http://example.com/base/url", rel: "canonical"})
       end
     end
 
-    it 'displays default canonical url' do
-      subject.display_meta_tags(site: 'someSite', canonical: 'http://example.com/base/url').tap do |meta|
-        expect(meta).to have_tag('link', with: { href: "http://example.com/base/url", rel: "canonical" })
+    it "displays default canonical url" do
+      subject.display_meta_tags(site: "someSite", canonical: "http://example.com/base/url").tap do |meta|
+        expect(meta).to have_tag("link", with: {href: "http://example.com/base/url", rel: "canonical"})
       end
     end
 
-    it 'does display canonical url when page is marked as noindex per default' do
-      subject.set_meta_tags(canonical: 'http://example.com/base/url', noindex: true)
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).to have_tag('link', with: { href: "http://example.com/base/url", rel: "canonical" })
+    it "does display canonical url when page is marked as noindex per default" do
+      subject.set_meta_tags(canonical: "http://example.com/base/url", noindex: true)
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).to have_tag("link", with: {href: "http://example.com/base/url", rel: "canonical"})
       end
     end
 
-    describe 'with config.skip_canonical_links_on_noindex is set' do
+    describe "with config.skip_canonical_links_on_noindex is set" do
       around do |example|
         default = MetaTags.config.skip_canonical_links_on_noindex
         MetaTags.config.skip_canonical_links_on_noindex = true
@@ -38,166 +38,166 @@ RSpec.describe MetaTags::ViewHelper do
         MetaTags.config.skip_canonical_links_on_noindex = default
       end
 
-      it 'does display canonical url when page is marked as index' do
-        subject.set_meta_tags(canonical: 'http://example.com/base/url', index: true)
-        subject.display_meta_tags(site: 'someSite').tap do |meta|
-          expect(meta).to have_tag('link', with: { href: "http://example.com/base/url", rel: "canonical" })
+      it "does display canonical url when page is marked as index" do
+        subject.set_meta_tags(canonical: "http://example.com/base/url", index: true)
+        subject.display_meta_tags(site: "someSite").tap do |meta|
+          expect(meta).to have_tag("link", with: {href: "http://example.com/base/url", rel: "canonical"})
         end
       end
 
-      it 'does not display canonical url when page is marked as noindex' do
-        subject.set_meta_tags(canonical: 'http://example.com/base/url', noindex: true)
-        subject.display_meta_tags(site: 'someSite').tap do |meta|
-          expect(meta).not_to have_tag('link', with: { href: "http://example.com/base/url", rel: "canonical" })
-          expect(meta).not_to have_tag('meta', with: { content: "http://example.com/base/url", name: "canonical" })
+      it "does not display canonical url when page is marked as noindex" do
+        subject.set_meta_tags(canonical: "http://example.com/base/url", noindex: true)
+        subject.display_meta_tags(site: "someSite").tap do |meta|
+          expect(meta).not_to have_tag("link", with: {href: "http://example.com/base/url", rel: "canonical"})
+          expect(meta).not_to have_tag("meta", with: {content: "http://example.com/base/url", name: "canonical"})
         end
       end
     end
   end
 
-  describe 'displaying alternate url' do
-    it 'does not display alternate url by default' do
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).not_to have_tag('link', with: { href: "http://example.fr/base/url", hreflang: "fr", rel: "alternate" })
+  describe "displaying alternate url" do
+    it "does not display alternate url by default" do
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).not_to have_tag("link", with: {href: "http://example.fr/base/url", hreflang: "fr", rel: "alternate"})
       end
     end
 
     it 'displays alternate url when "set_meta_tags" used' do
-      subject.set_meta_tags(alternate: { 'fr' => 'http://example.fr/base/url' })
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).to have_tag('link', with: { href: "http://example.fr/base/url", hreflang: "fr", rel: "alternate" })
+      subject.set_meta_tags(alternate: {"fr" => "http://example.fr/base/url"})
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).to have_tag("link", with: {href: "http://example.fr/base/url", hreflang: "fr", rel: "alternate"})
       end
     end
 
-    it 'displays default alternate url' do
-      subject.display_meta_tags(site: 'someSite', alternate: { 'fr' => 'http://example.fr/base/url' }).tap do |meta|
-        expect(meta).to have_tag('link', with: { href: "http://example.fr/base/url", hreflang: "fr", rel: "alternate" })
+    it "displays default alternate url" do
+      subject.display_meta_tags(site: "someSite", alternate: {"fr" => "http://example.fr/base/url"}).tap do |meta|
+        expect(meta).to have_tag("link", with: {href: "http://example.fr/base/url", hreflang: "fr", rel: "alternate"})
       end
     end
 
     it "does not display alternate without content" do
-      subject.display_meta_tags(site: 'someSite', alternate: { 'zh-Hant' => '' }).tap do |meta|
-        expect(meta).not_to have_tag('link', with: { href: "", hreflang: "zh-Hant", rel: "alternate" })
+      subject.display_meta_tags(site: "someSite", alternate: {"zh-Hant" => ""}).tap do |meta|
+        expect(meta).not_to have_tag("link", with: {href: "", hreflang: "zh-Hant", rel: "alternate"})
       end
     end
 
-    it 'allows to specify an array of alternate links' do
+    it "allows to specify an array of alternate links" do
       subject.display_meta_tags(
-        site:      'someSite',
+        site: "someSite",
         alternate: [
-          { href: 'http://example.fr/base/url', hreflang: 'fr' },
-          { href: 'http://example.com/feed.rss', type: 'application/rss+xml', title: 'RSS' },
-          { href: 'http://m.example.com/page-1', media: 'only screen and (max-width: 640px)' },
-        ],
+          {href: "http://example.fr/base/url", hreflang: "fr"},
+          {href: "http://example.com/feed.rss", type: "application/rss+xml", title: "RSS"},
+          {href: "http://m.example.com/page-1", media: "only screen and (max-width: 640px)"}
+        ]
       ).tap do |meta|
-        expect(meta).to have_tag('link', with: { href: "http://example.fr/base/url", hreflang: "fr", rel: "alternate" })
-        expect(meta).to have_tag('link', with: { href: "http://example.com/feed.rss", type: "application/rss+xml", title: 'RSS', rel: "alternate" })
-        expect(meta).to have_tag('link', with: { href: "http://m.example.com/page-1", media: 'only screen and (max-width: 640px)', rel: "alternate" })
+        expect(meta).to have_tag("link", with: {href: "http://example.fr/base/url", hreflang: "fr", rel: "alternate"})
+        expect(meta).to have_tag("link", with: {href: "http://example.com/feed.rss", type: "application/rss+xml", title: "RSS", rel: "alternate"})
+        expect(meta).to have_tag("link", with: {href: "http://m.example.com/page-1", media: "only screen and (max-width: 640px)", rel: "alternate"})
       end
     end
   end
 
-  describe 'displaying prev url' do
-    it 'does not display prev url by default' do
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).not_to have_tag('link', with: { href: "http://example.com/base/url", rel: "prev" })
+  describe "displaying prev url" do
+    it "does not display prev url by default" do
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).not_to have_tag("link", with: {href: "http://example.com/base/url", rel: "prev"})
       end
     end
 
     it 'displays prev url when "set_meta_tags" used' do
-      subject.set_meta_tags(prev: 'http://example.com/base/url')
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).to have_tag('link', with: { href: "http://example.com/base/url", rel: "prev" })
+      subject.set_meta_tags(prev: "http://example.com/base/url")
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).to have_tag("link", with: {href: "http://example.com/base/url", rel: "prev"})
       end
     end
 
-    it 'displays default prev url' do
-      subject.display_meta_tags(site: 'someSite', prev: 'http://example.com/base/url').tap do |meta|
-        expect(meta).to have_tag('link', with: { href: "http://example.com/base/url", rel: "prev" })
+    it "displays default prev url" do
+      subject.display_meta_tags(site: "someSite", prev: "http://example.com/base/url").tap do |meta|
+        expect(meta).to have_tag("link", with: {href: "http://example.com/base/url", rel: "prev"})
       end
     end
   end
 
-  describe 'displaying next url' do
-    it 'does not display next url by default' do
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).not_to have_tag('link', with: { href: "http://example.com/base/url", rel: "next" })
+  describe "displaying next url" do
+    it "does not display next url by default" do
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).not_to have_tag("link", with: {href: "http://example.com/base/url", rel: "next"})
       end
     end
 
     it 'displays next url when "set_meta_tags" used' do
-      subject.set_meta_tags(next: 'http://example.com/base/url')
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).to have_tag('link', with: { href: "http://example.com/base/url", rel: "next" })
+      subject.set_meta_tags(next: "http://example.com/base/url")
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).to have_tag("link", with: {href: "http://example.com/base/url", rel: "next"})
       end
     end
 
-    it 'displays default next url' do
-      subject.display_meta_tags(site: 'someSite', next: 'http://example.com/base/url').tap do |meta|
-        expect(meta).to have_tag('link', with: { href: "http://example.com/base/url", rel: "next" })
+    it "displays default next url" do
+      subject.display_meta_tags(site: "someSite", next: "http://example.com/base/url").tap do |meta|
+        expect(meta).to have_tag("link", with: {href: "http://example.com/base/url", rel: "next"})
       end
     end
   end
 
-  describe 'displaying image_src url' do
-    it 'does not display image_src url by default' do
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).not_to have_tag('link', with: { href: "http://example.com/base/url", rel: "image_src" })
+  describe "displaying image_src url" do
+    it "does not display image_src url by default" do
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).not_to have_tag("link", with: {href: "http://example.com/base/url", rel: "image_src"})
       end
     end
 
     it 'displays image_src url when "set_meta_tags" used' do
-      subject.set_meta_tags(image_src: 'http://example.com/base/url')
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).to have_tag('link', with: { href: "http://example.com/base/url", rel: "image_src" })
+      subject.set_meta_tags(image_src: "http://example.com/base/url")
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).to have_tag("link", with: {href: "http://example.com/base/url", rel: "image_src"})
       end
     end
 
-    it 'displays default image_src url' do
-      subject.display_meta_tags(site: 'someSite', image_src: 'http://example.com/base/url').tap do |meta|
-        expect(meta).to have_tag('link', with: { href: "http://example.com/base/url", rel: "image_src" })
+    it "displays default image_src url" do
+      subject.display_meta_tags(site: "someSite", image_src: "http://example.com/base/url").tap do |meta|
+        expect(meta).to have_tag("link", with: {href: "http://example.com/base/url", rel: "image_src"})
       end
     end
   end
 
-  describe 'displaying amphtml url' do
-    it 'does not display amphtml url by default' do
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).not_to have_tag('link', with: { href: "http://example.com/base/url.amp", rel: "amphtml" })
+  describe "displaying amphtml url" do
+    it "does not display amphtml url by default" do
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).not_to have_tag("link", with: {href: "http://example.com/base/url.amp", rel: "amphtml"})
       end
     end
 
     it 'displays amphtml url when "set_meta_tags" used' do
-      subject.set_meta_tags(amphtml: 'http://example.com/base/url.amp')
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).to have_tag('link', with: { href: "http://example.com/base/url.amp", rel: "amphtml" })
+      subject.set_meta_tags(amphtml: "http://example.com/base/url.amp")
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).to have_tag("link", with: {href: "http://example.com/base/url.amp", rel: "amphtml"})
       end
     end
 
-    it 'displays default amphtml url' do
-      subject.display_meta_tags(site: 'someSite', amphtml: 'http://example.com/base/url.amp').tap do |meta|
-        expect(meta).to have_tag('link', with: { href: "http://example.com/base/url.amp", rel: "amphtml" })
+    it "displays default amphtml url" do
+      subject.display_meta_tags(site: "someSite", amphtml: "http://example.com/base/url.amp").tap do |meta|
+        expect(meta).to have_tag("link", with: {href: "http://example.com/base/url.amp", rel: "amphtml"})
       end
     end
   end
 
-  describe 'displaying manifest url' do
-    it 'does not display manifest url by default' do
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).not_to have_tag('link', with: { rel: "manifest" })
+  describe "displaying manifest url" do
+    it "does not display manifest url by default" do
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).not_to have_tag("link", with: {rel: "manifest"})
       end
     end
 
     it 'displays manifest url when "set_meta_tags" used' do
-      subject.set_meta_tags(manifest: '/manifest.webmanifest')
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).to have_tag('link', with: { href: "/manifest.webmanifest", rel: "manifest" })
+      subject.set_meta_tags(manifest: "/manifest.webmanifest")
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).to have_tag("link", with: {href: "/manifest.webmanifest", rel: "manifest"})
       end
     end
 
-    it 'displays default manifest url' do
-      subject.display_meta_tags(site: 'someSite', manifest: '/manifest.webmanifest').tap do |meta|
-        expect(meta).to have_tag('link', with: { href: "/manifest.webmanifest", rel: "manifest" })
+    it "displays default manifest url" do
+      subject.display_meta_tags(site: "someSite", manifest: "/manifest.webmanifest").tap do |meta|
+        expect(meta).to have_tag("link", with: {href: "/manifest.webmanifest", rel: "manifest"})
       end
     end
   end

--- a/spec/view_helper/module_spec.rb
+++ b/spec/view_helper/module_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
-RSpec.describe MetaTags::ViewHelper, 'module' do
-  it 'is mixed into ActionView::Base' do
+RSpec.describe MetaTags::ViewHelper, "module" do
+  it "is mixed into ActionView::Base" do
     expect(ActionView::Base.included_modules).to include(described_class)
   end
 

--- a/spec/view_helper/noindex_spec.rb
+++ b/spec/view_helper/noindex_spec.rb
@@ -1,222 +1,222 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe MetaTags::ViewHelper do
-  describe 'displaying noindex' do
+  describe "displaying noindex" do
     it 'displays noindex when "noindex" used' do
       subject.noindex(true)
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).to have_tag('meta', with: { content: "noindex", name: "robots" })
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).to have_tag("meta", with: {content: "noindex", name: "robots"})
       end
     end
 
     it 'displays noindex when "set_meta_tags" used' do
       subject.set_meta_tags(noindex: true)
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).to have_tag('meta', with: { content: "noindex", name: "robots" })
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).to have_tag("meta", with: {content: "noindex", name: "robots"})
       end
     end
 
-    it 'uses custom noindex if given' do
-      subject.noindex('some-noindex')
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).to have_tag('meta', with: { content: "noindex", name: "some-noindex" })
+    it "uses custom noindex if given" do
+      subject.noindex("some-noindex")
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).to have_tag("meta", with: {content: "noindex", name: "some-noindex"})
       end
     end
 
-    it 'accepts multiple custom noindex robots in an array' do
-      subject.noindex(['some-noindex', 'another-noindex'])
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).to have_tag('meta', with: { content: "noindex", name: "some-noindex" })
-        expect(meta).to have_tag('meta', with: { content: "noindex", name: "another-noindex" })
+    it "accepts multiple custom noindex robots in an array" do
+      subject.noindex(["some-noindex", "another-noindex"])
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).to have_tag("meta", with: {content: "noindex", name: "some-noindex"})
+        expect(meta).to have_tag("meta", with: {content: "noindex", name: "another-noindex"})
       end
     end
 
-    it 'displays nothing by default' do
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).not_to have_tag('meta', with: { content: "noindex" })
+    it "displays nothing by default" do
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).not_to have_tag("meta", with: {content: "noindex"})
       end
     end
 
     it "displays nothing if given false" do
       subject.set_meta_tags(noindex: false)
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).not_to have_tag('meta', with: { content: "robots" })
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).not_to have_tag("meta", with: {content: "robots"})
       end
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).not_to have_tag('meta', with: { content: "noindex" })
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).not_to have_tag("meta", with: {content: "noindex"})
       end
     end
   end
 
-  describe 'displaying nofollow' do
+  describe "displaying nofollow" do
     it 'displays nofollow when "nofollow" used' do
       subject.nofollow(true)
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).to have_tag('meta', with: { content: "nofollow", name: "robots" })
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).to have_tag("meta", with: {content: "nofollow", name: "robots"})
       end
     end
 
     it 'displays nofollow when "set_meta_tags" used' do
       subject.set_meta_tags(nofollow: true)
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).to have_tag('meta', with: { content: "nofollow", name: "robots" })
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).to have_tag("meta", with: {content: "nofollow", name: "robots"})
       end
     end
 
-    it 'uses custom nofollow if given' do
-      subject.nofollow('some-nofollow')
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).to have_tag('meta', with: { content: "nofollow", name: "some-nofollow" })
+    it "uses custom nofollow if given" do
+      subject.nofollow("some-nofollow")
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).to have_tag("meta", with: {content: "nofollow", name: "some-nofollow"})
       end
     end
 
-    it 'accepts multiple custom nofollow robots in an array' do
-      subject.nofollow(['some-nofollow', 'another-nofollow'])
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).to have_tag('meta', with: { content: "nofollow", name: "some-nofollow" })
-        expect(meta).to have_tag('meta', with: { content: "nofollow", name: "another-nofollow" })
+    it "accepts multiple custom nofollow robots in an array" do
+      subject.nofollow(["some-nofollow", "another-nofollow"])
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).to have_tag("meta", with: {content: "nofollow", name: "some-nofollow"})
+        expect(meta).to have_tag("meta", with: {content: "nofollow", name: "another-nofollow"})
       end
     end
 
-    it 'displays nothing by default' do
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).not_to have_tag('meta', with: { content: "nofollow" })
+    it "displays nothing by default" do
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).not_to have_tag("meta", with: {content: "nofollow"})
       end
     end
   end
 
-  describe 'displaying both nofollow and noindex' do
-    it 'is displayed when set using helpers' do
+  describe "displaying both nofollow and noindex" do
+    it "is displayed when set using helpers" do
       subject.noindex(true)
       subject.nofollow(true)
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).to have_tag('meta', with: { content: "noindex, nofollow", name: "robots" })
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).to have_tag("meta", with: {content: "noindex, nofollow", name: "robots"})
       end
     end
 
     it 'is displayed when "set_meta_tags" used' do
       subject.set_meta_tags(nofollow: true, noindex: true)
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).to have_tag('meta', with: { content: "noindex, nofollow", name: "robots" })
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).to have_tag("meta", with: {content: "noindex, nofollow", name: "robots"})
       end
     end
 
     it 'displays two meta tags when different names used with "set_meta_tags"' do
-      subject.set_meta_tags(noindex: 'robots', nofollow: 'googlebot')
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).to have_tag('meta', with: { content: 'noindex', name: 'robots' })
-        expect(meta).to have_tag('meta', with: { content: 'nofollow', name: 'googlebot' })
+      subject.set_meta_tags(noindex: "robots", nofollow: "googlebot")
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).to have_tag("meta", with: {content: "noindex", name: "robots"})
+        expect(meta).to have_tag("meta", with: {content: "nofollow", name: "googlebot"})
       end
     end
 
-    it 'uses custom name if string is used' do
-      subject.noindex('some-name')
-      subject.nofollow('some-name')
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).to have_tag('meta', with: { content: "noindex, nofollow", name: "some-name" })
+    it "uses custom name if string is used" do
+      subject.noindex("some-name")
+      subject.nofollow("some-name")
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).to have_tag("meta", with: {content: "noindex, nofollow", name: "some-name"})
       end
     end
 
-    it 'displays two meta tags when different names used' do
-      subject.noindex('some-noindex')
-      subject.nofollow('some-nofollow')
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).to have_tag('meta', with: { content: "noindex", name: "some-noindex" })
-        expect(meta).to have_tag('meta', with: { content: "nofollow", name: "some-nofollow" })
+    it "displays two meta tags when different names used" do
+      subject.noindex("some-noindex")
+      subject.nofollow("some-nofollow")
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).to have_tag("meta", with: {content: "noindex", name: "some-noindex"})
+        expect(meta).to have_tag("meta", with: {content: "nofollow", name: "some-nofollow"})
       end
     end
   end
 
-  context 'when displaying both follow and index' do
+  context "when displaying both follow and index" do
     it 'renders when "set_meta_tags" used' do
       subject.set_meta_tags(follow: true, index: true)
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).to have_tag('meta', with: { content: "index, follow", name: "robots" })
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).to have_tag("meta", with: {content: "index, follow", name: "robots"})
       end
     end
 
-    it 'uses custom name if string is used' do
-      subject.set_meta_tags(follow: 'some-name123', index: 'some-name123')
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).to have_tag('meta', with: { content: "index, follow", name: "some-name123" })
+    it "uses custom name if string is used" do
+      subject.set_meta_tags(follow: "some-name123", index: "some-name123")
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).to have_tag("meta", with: {content: "index, follow", name: "some-name123"})
       end
     end
 
-    it 'renders two meta tags when different names used' do
-      subject.set_meta_tags(follow: 'some-follow', index: 'some-index')
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).to have_tag('meta', with: { content: "index", name: "some-index" })
-        expect(meta).to have_tag('meta', with: { content: "follow", name: "some-follow" })
+    it "renders two meta tags when different names used" do
+      subject.set_meta_tags(follow: "some-follow", index: "some-index")
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).to have_tag("meta", with: {content: "index", name: "some-index"})
+        expect(meta).to have_tag("meta", with: {content: "follow", name: "some-follow"})
       end
     end
   end
 
-  context 'when displaying both follow and noindex when nofollow and index set by mistake' do
+  context "when displaying both follow and noindex when nofollow and index set by mistake" do
     it 'renders when "set_meta_tags" used' do
       subject.set_meta_tags(follow: true, index: true, nofollow: true, noindex: true)
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).to have_tag('meta', with: { content: "noindex, follow", name: "robots" })
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).to have_tag("meta", with: {content: "noindex, follow", name: "robots"})
       end
     end
 
-    it 'uses custom name if string is used' do
-      subject.set_meta_tags(follow: 'some-name', index: 'some-name', nofollow: 'some-name', noindex: 'some-name')
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).to have_tag('meta', with: { content: "noindex, follow", name: "some-name" })
+    it "uses custom name if string is used" do
+      subject.set_meta_tags(follow: "some-name", index: "some-name", nofollow: "some-name", noindex: "some-name")
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).to have_tag("meta", with: {content: "noindex, follow", name: "some-name"})
       end
     end
 
-    it 'renders two meta tags when different names used' do
-      subject.set_meta_tags(follow: 'some-follow', index: 'some-index', nofollow: 'some-nofollow', noindex: 'some-noindex')
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).to have_tag('meta', with: { content: "index", name: "some-index" })
-        expect(meta).to have_tag('meta', with: { content: "follow", name: "some-follow" })
-        expect(meta).to have_tag('meta', with: { content: "noindex", name: "some-noindex" })
-        expect(meta).to have_tag('meta', with: { content: "nofollow", name: "some-nofollow" })
+    it "renders two meta tags when different names used" do
+      subject.set_meta_tags(follow: "some-follow", index: "some-index", nofollow: "some-nofollow", noindex: "some-noindex")
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).to have_tag("meta", with: {content: "index", name: "some-index"})
+        expect(meta).to have_tag("meta", with: {content: "follow", name: "some-follow"})
+        expect(meta).to have_tag("meta", with: {content: "noindex", name: "some-noindex"})
+        expect(meta).to have_tag("meta", with: {content: "nofollow", name: "some-nofollow"})
       end
     end
   end
 
-  context 'when displaying noarchive' do
+  context "when displaying noarchive" do
     it 'renders noarchive when "set_meta_tags" used' do
       subject.set_meta_tags(noarchive: true)
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).to have_tag('meta', with: { content: "noarchive", name: "robots" })
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).to have_tag("meta", with: {content: "noarchive", name: "robots"})
       end
     end
 
-    it 'renders nothing if given false' do
+    it "renders nothing if given false" do
       subject.set_meta_tags(noarchive: false)
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).not_to have_tag('meta', with: { content: "noarchive", name: "robots" })
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).not_to have_tag("meta", with: {content: "noarchive", name: "robots"})
       end
     end
 
-    it 'uses custom noarchive if given' do
-      subject.set_meta_tags(noarchive: 'some-robots')
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).to have_tag('meta', with: { content: "noarchive", name: "some-robots" })
+    it "uses custom noarchive if given" do
+      subject.set_meta_tags(noarchive: "some-robots")
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).to have_tag("meta", with: {content: "noarchive", name: "some-robots"})
       end
     end
   end
 
-  it 'properly handles priorities and multiple robot names' do
+  it "properly handles priorities and multiple robot names" do
     subject.set_meta_tags(
-      noindex:   true,
-      index:     'yahoo',
-      follow:    ['google', 'yahoo', 'github'],
-      nofollow:  ['yandex', :google],
-      noarchive: ['yahoo', 'bing'],
+      noindex: true,
+      index: "yahoo",
+      follow: ["google", "yahoo", "github"],
+      nofollow: ["yandex", :google],
+      noarchive: ["yahoo", "bing"]
     )
-    subject.display_meta_tags(site: 'someSite').tap do |meta|
-      expect(meta).to have_tag('meta', with: { name: "robots", content: "noindex" })
-      expect(meta).to have_tag('meta', with: { name: "yahoo", content: "index, follow, noarchive" })
-      expect(meta).to have_tag('meta', with: { name: "google", content: "follow" })
-      expect(meta).to have_tag('meta', with: { name: "github", content: "follow" })
-      expect(meta).to have_tag('meta', with: { name: "yandex", content: "nofollow" })
-      expect(meta).to have_tag('meta', with: { name: "bing", content: "noarchive" })
+    subject.display_meta_tags(site: "someSite").tap do |meta|
+      expect(meta).to have_tag("meta", with: {name: "robots", content: "noindex"})
+      expect(meta).to have_tag("meta", with: {name: "yahoo", content: "index, follow, noarchive"})
+      expect(meta).to have_tag("meta", with: {name: "google", content: "follow"})
+      expect(meta).to have_tag("meta", with: {name: "github", content: "follow"})
+      expect(meta).to have_tag("meta", with: {name: "yandex", content: "nofollow"})
+      expect(meta).to have_tag("meta", with: {name: "bing", content: "noarchive"})
     end
   end
 end

--- a/spec/view_helper/open_graph_spec.rb
+++ b/spec/view_helper/open_graph_spec.rb
@@ -1,122 +1,122 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
-RSpec.describe MetaTags::ViewHelper, 'displaying Open Graph meta tags' do
-  it 'displays meta tags specified with :open_graph' do
+RSpec.describe MetaTags::ViewHelper, "displaying Open Graph meta tags" do
+  it "displays meta tags specified with :open_graph" do
     subject.set_meta_tags(
       open_graph: {
-        title:       'Facebook Share Title',
-        description: 'Facebook Share Description',
-      },
+        title: "Facebook Share Title",
+        description: "Facebook Share Description"
+      }
     )
-    subject.display_meta_tags(site: 'someSite').tap do |meta|
-      expect(meta).to have_tag('meta', with: { content: "Facebook Share Title", property: "og:title" })
-      expect(meta).to have_tag('meta', with: { content: "Facebook Share Description", property: "og:description" })
+    subject.display_meta_tags(site: "someSite").tap do |meta|
+      expect(meta).to have_tag("meta", with: {content: "Facebook Share Title", property: "og:title"})
+      expect(meta).to have_tag("meta", with: {content: "Facebook Share Description", property: "og:description"})
     end
   end
 
-  it 'displays meta tags specified with :og' do
+  it "displays meta tags specified with :og" do
     subject.set_meta_tags(
       og: {
-        title:       'Facebook Share Title',
-        description: 'Facebook Share Description',
-      },
+        title: "Facebook Share Title",
+        description: "Facebook Share Description"
+      }
     )
-    subject.display_meta_tags(site: 'someSite').tap do |meta|
-      expect(meta).to have_tag('meta', with: { content: "Facebook Share Title", property: "og:title" })
-      expect(meta).to have_tag('meta', with: { content: "Facebook Share Description", property: "og:description" })
+    subject.display_meta_tags(site: "someSite").tap do |meta|
+      expect(meta).to have_tag("meta", with: {content: "Facebook Share Title", property: "og:title"})
+      expect(meta).to have_tag("meta", with: {content: "Facebook Share Description", property: "og:description"})
     end
   end
 
-  it 'uses deep merge when displaying open graph meta tags' do
-    subject.set_meta_tags(og: { title: 'Facebook Share Title' })
-    subject.display_meta_tags(og: { description: 'Facebook Share Description' }).tap do |meta|
-      expect(meta).to have_tag('meta', with: { content: "Facebook Share Title", property: "og:title" })
-      expect(meta).to have_tag('meta', with: { content: "Facebook Share Description", property: "og:description" })
+  it "uses deep merge when displaying open graph meta tags" do
+    subject.set_meta_tags(og: {title: "Facebook Share Title"})
+    subject.display_meta_tags(og: {description: "Facebook Share Description"}).tap do |meta|
+      expect(meta).to have_tag("meta", with: {content: "Facebook Share Title", property: "og:title"})
+      expect(meta).to have_tag("meta", with: {content: "Facebook Share Description", property: "og:description"})
     end
   end
 
   it "does not display meta tags without content" do
     subject.set_meta_tags(
       open_graph: {
-        title:       '',
-        description: '',
-      },
+        title: "",
+        description: ""
+      }
     )
-    subject.display_meta_tags(site: 'someSite').tap do |meta|
-      expect(meta).not_to have_tag('meta', with: { content: "", property: "og:title" })
-      expect(meta).not_to have_tag('meta', with: { content: "", property: "og:description" })
+    subject.display_meta_tags(site: "someSite").tap do |meta|
+      expect(meta).not_to have_tag("meta", with: {content: "", property: "og:title"})
+      expect(meta).not_to have_tag("meta", with: {content: "", property: "og:description"})
     end
   end
 
   it "displays locale meta tags" do
-    subject.display_meta_tags(open_graph: { locale: { _: 'en_GB', alternate: ['fr_FR', 'es_ES'] } }).tap do |meta|
-      expect(meta).to have_tag('meta', with: { content: "en_GB", property: "og:locale" })
-      expect(meta).to have_tag('meta', with: { content: "fr_FR", property: "og:locale:alternate" })
-      expect(meta).to have_tag('meta', with: { content: "es_ES", property: "og:locale:alternate" })
+    subject.display_meta_tags(open_graph: {locale: {_: "en_GB", alternate: ["fr_FR", "es_ES"]}}).tap do |meta|
+      expect(meta).to have_tag("meta", with: {content: "en_GB", property: "og:locale"})
+      expect(meta).to have_tag("meta", with: {content: "fr_FR", property: "og:locale:alternate"})
+      expect(meta).to have_tag("meta", with: {content: "es_ES", property: "og:locale:alternate"})
     end
   end
 
   it "displays mirrored content" do
-    subject.set_meta_tags(title: 'someTitle')
-    subject.display_meta_tags(open_graph: { title: :title }).tap do |meta|
-      expect(meta).to have_tag('meta', with: { content: "someTitle", property: "og:title" })
+    subject.set_meta_tags(title: "someTitle")
+    subject.display_meta_tags(open_graph: {title: :title}).tap do |meta|
+      expect(meta).to have_tag("meta", with: {content: "someTitle", property: "og:title"})
     end
   end
 
   it "properly handle title and site title in mirrored content" do
-    subject.set_meta_tags(title: 'someTitle', site: 'someSite')
-    subject.display_meta_tags(open_graph: { title: :title, site_name: :site, full_title: :full_title }).tap do |meta|
-      expect(meta).to have_tag('meta', with: { content: "someTitle", property: "og:title" })
-      expect(meta).to have_tag('meta', with: { content: "someSite", property: "og:site_name" })
-      expect(meta).to have_tag('meta', with: { content: "someSite | someTitle", property: "og:full_title" })
+    subject.set_meta_tags(title: "someTitle", site: "someSite")
+    subject.display_meta_tags(open_graph: {title: :title, site_name: :site, full_title: :full_title}).tap do |meta|
+      expect(meta).to have_tag("meta", with: {content: "someTitle", property: "og:title"})
+      expect(meta).to have_tag("meta", with: {content: "someSite", property: "og:site_name"})
+      expect(meta).to have_tag("meta", with: {content: "someSite | someTitle", property: "og:full_title"})
     end
   end
 
   it "uses site_title for mirrored title, when title is empty" do
-    subject.set_meta_tags(title: '', site: 'someSite')
-    subject.display_meta_tags(open_graph: { title: :title, site_name: :site, full_title: :full_title }).tap do |meta|
-      expect(meta).to have_tag('meta', with: { content: "someSite", property: "og:title" })
-      expect(meta).to have_tag('meta', with: { content: "someSite", property: "og:site_name" })
-      expect(meta).to have_tag('meta', with: { content: "someSite", property: "og:full_title" })
+    subject.set_meta_tags(title: "", site: "someSite")
+    subject.display_meta_tags(open_graph: {title: :title, site_name: :site, full_title: :full_title}).tap do |meta|
+      expect(meta).to have_tag("meta", with: {content: "someSite", property: "og:title"})
+      expect(meta).to have_tag("meta", with: {content: "someSite", property: "og:site_name"})
+      expect(meta).to have_tag("meta", with: {content: "someSite", property: "og:full_title"})
     end
   end
 
   it "displays open graph meta tags with an array of images" do
     subject.set_meta_tags(
       open_graph: {
-        title: 'someTitle',
+        title: "someTitle",
         image: [
           {
-            _:      'http://example.com/1.png',
-            width:  75,
-            height: 75,
+            _: "http://example.com/1.png",
+            width: 75,
+            height: 75
           },
           {
-            _:      'http://example.com/2.png',
-            width:  50,
-            height: 50,
-          },
-        ],
-      },
+            _: "http://example.com/2.png",
+            width: 50,
+            height: 50
+          }
+        ]
+      }
     )
-    subject.display_meta_tags(site: 'someTitle').tap do |meta|
-      expect(meta).to have_tag('meta', with: { content: "someTitle", property: "og:title" })
-      expect(meta).to have_tag('meta', with: { content: "http://example.com/1.png", property: "og:image" })
-      expect(meta).to have_tag('meta', with: { content: "75", property: "og:image:width" })
-      expect(meta).to have_tag('meta', with: { content: "75", property: "og:image:height" })
-      expect(meta).to have_tag('meta', with: { content: "http://example.com/2.png", property: "og:image" })
-      expect(meta).to have_tag('meta', with: { content: "50", property: "og:image:width" })
-      expect(meta).to have_tag('meta', with: { content: "50", property: "og:image:height" })
+    subject.display_meta_tags(site: "someTitle").tap do |meta|
+      expect(meta).to have_tag("meta", with: {content: "someTitle", property: "og:title"})
+      expect(meta).to have_tag("meta", with: {content: "http://example.com/1.png", property: "og:image"})
+      expect(meta).to have_tag("meta", with: {content: "75", property: "og:image:width"})
+      expect(meta).to have_tag("meta", with: {content: "75", property: "og:image:height"})
+      expect(meta).to have_tag("meta", with: {content: "http://example.com/2.png", property: "og:image"})
+      expect(meta).to have_tag("meta", with: {content: "50", property: "og:image:width"})
+      expect(meta).to have_tag("meta", with: {content: "50", property: "og:image:height"})
     end
   end
 
   it "formats dates using ISO 8601" do
     time = Time.now.utc
-    subject.set_meta_tags(article: { published_time: time })
-    subject.display_meta_tags(site: 'someSite').tap do |meta|
-      expect(meta).to have_tag('meta', with: { content: time.iso8601, property: "article:published_time" })
+    subject.set_meta_tags(article: {published_time: time})
+    subject.display_meta_tags(site: "someSite").tap do |meta|
+      expect(meta).to have_tag("meta", with: {content: time.iso8601, property: "article:published_time"})
     end
   end
 end

--- a/spec/view_helper/open_search_spec.rb
+++ b/spec/view_helper/open_search_spec.rb
@@ -1,42 +1,42 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
-RSpec.describe MetaTags::ViewHelper, 'displaying Open Search meta tags' do
-  it 'displays meta tags specified with :open_search' do
+RSpec.describe MetaTags::ViewHelper, "displaying Open Search meta tags" do
+  it "displays meta tags specified with :open_search" do
     subject.set_meta_tags(
       open_search: {
-        title: 'Open Search Title',
-        href:  '/open_search_path.xml',
-      },
+        title: "Open Search Title",
+        href: "/open_search_path.xml"
+      }
     )
-    subject.display_meta_tags(site: 'someSite').tap do |meta|
+    subject.display_meta_tags(site: "someSite").tap do |meta|
       expect(meta).to have_tag(
-        'link',
+        "link",
         with: {
-          href:  '/open_search_path.xml',
-          rel:   'search',
-          title: 'Open Search Title',
-          type:  'application/opensearchdescription+xml',
-        },
+          href: "/open_search_path.xml",
+          rel: "search",
+          title: "Open Search Title",
+          type: "application/opensearchdescription+xml"
+        }
       )
     end
   end
 
-  it 'does not display meta tags without content' do
+  it "does not display meta tags without content" do
     subject.set_meta_tags(
       open_search: {
-        title: '',
-        href:  '',
-      },
+        title: "",
+        href: ""
+      }
     )
-    subject.display_meta_tags(site: 'someSite').tap do |meta|
+    subject.display_meta_tags(site: "someSite").tap do |meta|
       expect(meta).not_to have_tag(
-        'link',
+        "link",
         with: {
-          rel:  'search',
-          type: 'application/opensearchdescription+xml',
-        },
+          rel: "search",
+          type: "application/opensearchdescription+xml"
+        }
       )
     end
   end

--- a/spec/view_helper/open_tags_spec.rb
+++ b/spec/view_helper/open_tags_spec.rb
@@ -1,23 +1,23 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
-RSpec.describe MetaTags::ViewHelper, 'meta tags' do
+RSpec.describe MetaTags::ViewHelper, "meta tags" do
   context "with open_meta_tags=true" do
-    it 'generates open charset tag' do
-      subject.display_meta_tags(charset: 'UTF-8').tap do |meta|
+    it "generates open charset tag" do
+      subject.display_meta_tags(charset: "UTF-8").tap do |meta|
         expect(meta).to eq('<meta charset="UTF-8">')
       end
     end
 
-    it 'generates open meta tags' do
-      subject.display_meta_tags(open_graph: { title: 'someSite' }).tap do |meta|
+    it "generates open meta tags" do
+      subject.display_meta_tags(open_graph: {title: "someSite"}).tap do |meta|
         expect(meta).to eq('<meta property="og:title" content="someSite">')
       end
     end
 
-    it 'generates open link tags' do
-      subject.display_meta_tags(canonical: 'http://example.com/base/url').tap do |meta|
+    it "generates open link tags" do
+      subject.display_meta_tags(canonical: "http://example.com/base/url").tap do |meta|
         expect(meta).to eq('<link rel="canonical" href="http://example.com/base/url">')
       end
     end
@@ -28,20 +28,20 @@ RSpec.describe MetaTags::ViewHelper, 'meta tags' do
       MetaTags.config.open_meta_tags = false
     end
 
-    it 'generates closed charset tag' do
-      subject.display_meta_tags(charset: 'UTF-8').tap do |meta|
+    it "generates closed charset tag" do
+      subject.display_meta_tags(charset: "UTF-8").tap do |meta|
         expect(meta).to eq('<meta charset="UTF-8" />')
       end
     end
 
-    it 'generates closed meta tags' do
-      subject.display_meta_tags(open_graph: { title: 'someSite' }).tap do |meta|
+    it "generates closed meta tags" do
+      subject.display_meta_tags(open_graph: {title: "someSite"}).tap do |meta|
         expect(meta).to eq('<meta property="og:title" content="someSite" />')
       end
     end
 
-    it 'generates closed link tags' do
-      subject.display_meta_tags(canonical: 'http://example.com/base/url').tap do |meta|
+    it "generates closed link tags" do
+      subject.display_meta_tags(canonical: "http://example.com/base/url").tap do |meta|
         expect(meta).to eq('<link rel="canonical" href="http://example.com/base/url" />')
       end
     end

--- a/spec/view_helper/refresh_spec.rb
+++ b/spec/view_helper/refresh_spec.rb
@@ -1,32 +1,32 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
-RSpec.describe MetaTags::ViewHelper, 'displaying refresh' do
+RSpec.describe MetaTags::ViewHelper, "displaying refresh" do
   it 'displays refresh when "refresh" is used' do
     subject.refresh(5)
-    subject.display_meta_tags(site: 'someSite').tap do |meta|
-      expect(meta).to have_tag('meta', with: { content: '5', 'http-equiv' => 'refresh' })
+    subject.display_meta_tags(site: "someSite").tap do |meta|
+      expect(meta).to have_tag("meta", with: {:content => "5", "http-equiv" => "refresh"})
     end
   end
 
   it 'displays refresh when "set_meta_tags" used' do
     subject.set_meta_tags(refresh: 5)
-    subject.display_meta_tags(site: 'someSite').tap do |meta|
-      expect(meta).to have_tag('meta', with: { content: '5', 'http-equiv' => 'refresh' })
+    subject.display_meta_tags(site: "someSite").tap do |meta|
+      expect(meta).to have_tag("meta", with: {:content => "5", "http-equiv" => "refresh"})
     end
   end
 
-  it 'uses custom refresh if given' do
+  it "uses custom refresh if given" do
     subject.refresh("5;url=http://example.com/")
-    subject.display_meta_tags(site: 'someSite').tap do |meta|
-      expect(meta).to have_tag('meta', with: { content: '5;url=http://example.com/', 'http-equiv' => "refresh" })
+    subject.display_meta_tags(site: "someSite").tap do |meta|
+      expect(meta).to have_tag("meta", with: {:content => "5;url=http://example.com/", "http-equiv" => "refresh"})
     end
   end
 
-  it 'displays nothing by default' do
-    subject.display_meta_tags(site: 'someSite').tap do |meta|
-      expect(meta).not_to have_tag('meta', with: { 'http-equiv' => "refresh" })
+  it "displays nothing by default" do
+    subject.display_meta_tags(site: "someSite").tap do |meta|
+      expect(meta).not_to have_tag("meta", with: {"http-equiv" => "refresh"})
     end
   end
 end

--- a/spec/view_helper/title_spec.rb
+++ b/spec/view_helper/title_spec.rb
@@ -1,225 +1,225 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe MetaTags::ViewHelper do
-  describe 'displaying title' do
-    it 'does not display title if blank' do
-      expect(subject.display_meta_tags).to eq('')
-      subject.title('')
-      expect(subject.display_meta_tags).to eq('')
+  describe "displaying title" do
+    it "does not display title if blank" do
+      expect(subject.display_meta_tags).to eq("")
+      subject.title("")
+      expect(subject.display_meta_tags).to eq("")
     end
 
-    it 'uses website name if title is empty' do
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).to eq('<title>someSite</title>')
+    it "uses website name if title is empty" do
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).to eq("<title>someSite</title>")
       end
     end
 
     it 'displays title when "title" used' do
-      subject.title('someTitle')
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).to eq('<title>someSite | someTitle</title>')
+      subject.title("someTitle")
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).to eq("<title>someSite | someTitle</title>")
       end
     end
 
     it 'displays title only when "site" is empty' do
-      subject.title('someTitle')
-      expect(subject.display_meta_tags).to eq('<title>someTitle</title>')
+      subject.title("someTitle")
+      expect(subject.display_meta_tags).to eq("<title>someTitle</title>")
     end
 
     it 'displays title when "set_meta_tags" is used' do
-      subject.set_meta_tags(title: 'someTitle')
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).to eq('<title>someSite | someTitle</title>')
+      subject.set_meta_tags(title: "someTitle")
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).to eq("<title>someSite | someTitle</title>")
       end
     end
 
     it 'escapes the title when "set_meta_tags" is used' do
-      subject.set_meta_tags(title: 'someTitle & somethingElse')
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).to eq('<title>someSite | someTitle &amp; somethingElse</title>')
+      subject.set_meta_tags(title: "someTitle & somethingElse")
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).to eq("<title>someSite | someTitle &amp; somethingElse</title>")
       end
     end
 
     it 'escapes a very long title when "set_meta_tags" is used' do
-      subject.set_meta_tags(title: 'Kombucha kale chips forage try-hard & green juice. IPhone marfa PBR&B venmo listicle, irony kitsch thundercats.')
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).to eq('<title>someSite | Kombucha kale chips forage try-hard &amp; green juice. IPhone</title>')
+      subject.set_meta_tags(title: "Kombucha kale chips forage try-hard & green juice. IPhone marfa PBR&B venmo listicle, irony kitsch thundercats.")
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).to eq("<title>someSite | Kombucha kale chips forage try-hard &amp; green juice. IPhone</title>")
       end
     end
 
-    it 'strips tags in the title' do
-      subject.set_meta_tags(title: '<b>hackxor</b>')
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).to eq('<title>someSite | hackxor</title>')
+    it "strips tags in the title" do
+      subject.set_meta_tags(title: "<b>hackxor</b>")
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).to eq("<title>someSite | hackxor</title>")
       end
     end
 
-    it 'strips tags from very long titles' do
-      subject.set_meta_tags(title: 'Kombucha <b>kale</b> chips forage try-hard & green juice. IPhone marfa PBR&B venmo listicle, irony kitsch thundercats.')
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).to eq('<title>someSite | Kombucha kale chips forage try-hard &amp; green juice. IPhone</title>')
+    it "strips tags from very long titles" do
+      subject.set_meta_tags(title: "Kombucha <b>kale</b> chips forage try-hard & green juice. IPhone marfa PBR&B venmo listicle, irony kitsch thundercats.")
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).to eq("<title>someSite | Kombucha kale chips forage try-hard &amp; green juice. IPhone</title>")
       end
     end
 
-    it 'displays custom title if given' do
-      subject.title('someTitle')
-      subject.display_meta_tags(site: 'someSite', title: 'defaultTitle').tap do |meta|
-        expect(meta).to eq('<title>someSite | someTitle</title>')
+    it "displays custom title if given" do
+      subject.title("someTitle")
+      subject.display_meta_tags(site: "someSite", title: "defaultTitle").tap do |meta|
+        expect(meta).to eq("<title>someSite | someTitle</title>")
       end
     end
 
-    it 'uses website before page by default' do
-      subject.display_meta_tags(site: 'someSite', title: 'someTitle').tap do |meta|
-        expect(meta).to eq('<title>someSite | someTitle</title>')
+    it "uses website before page by default" do
+      subject.display_meta_tags(site: "someSite", title: "someTitle").tap do |meta|
+        expect(meta).to eq("<title>someSite | someTitle</title>")
       end
     end
 
-    it 'onlies use markup in titles in the view' do
-      expect(subject.title('<b>someTitle</b>')).to eq('<b>someTitle</b>')
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).to eq('<title>someSite | someTitle</title>')
+    it "onlies use markup in titles in the view" do
+      expect(subject.title("<b>someTitle</b>")).to eq("<b>someTitle</b>")
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).to eq("<title>someSite | someTitle</title>")
       end
     end
 
-    it 'uses page before website if :reverse' do
-      subject.display_meta_tags(site: 'someSite', title: 'someTitle', reverse: true).tap do |meta|
-        expect(meta).to eq('<title>someTitle | someSite</title>')
+    it "uses page before website if :reverse" do
+      subject.display_meta_tags(site: "someSite", title: "someTitle", reverse: true).tap do |meta|
+        expect(meta).to eq("<title>someTitle | someSite</title>")
       end
     end
 
-    it 'is lowercase if :lowercase' do
-      subject.display_meta_tags(site: 'someSite', title: 'someTitle', lowercase: true).tap do |meta|
-        expect(meta).to eq('<title>someSite | sometitle</title>')
+    it "is lowercase if :lowercase" do
+      subject.display_meta_tags(site: "someSite", title: "someTitle", lowercase: true).tap do |meta|
+        expect(meta).to eq("<title>someSite | sometitle</title>")
       end
     end
 
-    it 'does not change original title string' do
+    it "does not change original title string" do
       title = "TITLE"
       subject.display_meta_tags(title: title, lowercase: true).tap do |meta|
-        expect(meta).to eq('<title>title</title>')
+        expect(meta).to eq("<title>title</title>")
       end
-      expect(title).to eq('TITLE')
+      expect(title).to eq("TITLE")
     end
 
-    it 'uses custom separator when :separator specified' do
-      subject.title('someTitle')
-      subject.display_meta_tags(site: 'someSite', separator: '-').tap do |meta|
-        expect(meta).to eq('<title>someSite - someTitle</title>')
+    it "uses custom separator when :separator specified" do
+      subject.title("someTitle")
+      subject.display_meta_tags(site: "someSite", separator: "-").tap do |meta|
+        expect(meta).to eq("<title>someSite - someTitle</title>")
       end
-      subject.display_meta_tags(site: 'someSite', separator: ':').tap do |meta|
-        expect(meta).to eq('<title>someSite : someTitle</title>')
+      subject.display_meta_tags(site: "someSite", separator: ":").tap do |meta|
+        expect(meta).to eq("<title>someSite : someTitle</title>")
       end
-      subject.display_meta_tags(site: 'someSite', separator: '&amp;').tap do |meta|
-        expect(meta).to eq('<title>someSite &amp;amp; someTitle</title>')
+      subject.display_meta_tags(site: "someSite", separator: "&amp;").tap do |meta|
+        expect(meta).to eq("<title>someSite &amp;amp; someTitle</title>")
       end
-      subject.display_meta_tags(site: 'someSite', separator: '&').tap do |meta|
-        expect(meta).to eq('<title>someSite &amp; someTitle</title>')
+      subject.display_meta_tags(site: "someSite", separator: "&").tap do |meta|
+        expect(meta).to eq("<title>someSite &amp; someTitle</title>")
       end
-      subject.display_meta_tags(site: 'someSite', separator: '&amp;'.html_safe).tap do |meta|
-        expect(meta).to eq('<title>someSite &amp; someTitle</title>')
+      subject.display_meta_tags(site: "someSite", separator: "&amp;".html_safe).tap do |meta|
+        expect(meta).to eq("<title>someSite &amp; someTitle</title>")
       end
-      subject.display_meta_tags(site: 'someSite:', separator: false).tap do |meta|
-        expect(meta).to eq('<title>someSite:someTitle</title>')
-      end
-    end
-
-    it 'uses custom prefix and suffix if available' do
-      subject.display_meta_tags(site: 'someSite', title: 'someTitle', prefix: ' -', suffix: '- ').tap do |meta|
-        expect(meta).to eq('<title>someSite -|- someTitle</title>')
+      subject.display_meta_tags(site: "someSite:", separator: false).tap do |meta|
+        expect(meta).to eq("<title>someSite:someTitle</title>")
       end
     end
 
-    it 'collapses prefix if false' do
-      subject.display_meta_tags(site: 'someSite', title: 'someTitle', prefix: false).tap do |meta|
-        expect(meta).to eq('<title>someSite| someTitle</title>')
+    it "uses custom prefix and suffix if available" do
+      subject.display_meta_tags(site: "someSite", title: "someTitle", prefix: " -", suffix: "- ").tap do |meta|
+        expect(meta).to eq("<title>someSite -|- someTitle</title>")
       end
     end
 
-    it 'collapses suffix if false' do
-      subject.display_meta_tags(site: 'someSite', title: 'someTitle', suffix: false).tap do |meta|
-        expect(meta).to eq('<title>someSite |someTitle</title>')
+    it "collapses prefix if false" do
+      subject.display_meta_tags(site: "someSite", title: "someTitle", prefix: false).tap do |meta|
+        expect(meta).to eq("<title>someSite| someTitle</title>")
       end
     end
 
-    it 'uses all custom options if available' do
+    it "collapses suffix if false" do
+      subject.display_meta_tags(site: "someSite", title: "someTitle", suffix: false).tap do |meta|
+        expect(meta).to eq("<title>someSite |someTitle</title>")
+      end
+    end
+
+    it "uses all custom options if available" do
       subject.display_meta_tags(
-        site:      'someSite',
-        title:     'someTitle',
-        prefix:    ' -',
-        suffix:    '+ ',
-        separator: ':',
+        site: "someSite",
+        title: "someTitle",
+        prefix: " -",
+        suffix: "+ ",
+        separator: ":",
         lowercase: true,
-        reverse:   true,
+        reverse: true
       ).tap do |meta|
-        expect(meta).to eq('<title>sometitle -:+ someSite</title>')
+        expect(meta).to eq("<title>sometitle -:+ someSite</title>")
       end
     end
 
-    it 'allows Arrays in title' do
-      subject.display_meta_tags(site: 'someSite', title: ['someTitle', 'anotherTitle']).tap do |meta|
-        expect(meta).to eq('<title>someSite | someTitle | anotherTitle</title>')
+    it "allows Arrays in title" do
+      subject.display_meta_tags(site: "someSite", title: ["someTitle", "anotherTitle"]).tap do |meta|
+        expect(meta).to eq("<title>someSite | someTitle | anotherTitle</title>")
       end
     end
 
-    it 'allows Arrays in title with :lowercase' do
-      subject.display_meta_tags(site: 'someSite', title: ['someTitle', 'anotherTitle'], lowercase: true).tap do |meta|
-        expect(meta).to eq('<title>someSite | sometitle | anothertitle</title>')
+    it "allows Arrays in title with :lowercase" do
+      subject.display_meta_tags(site: "someSite", title: ["someTitle", "anotherTitle"], lowercase: true).tap do |meta|
+        expect(meta).to eq("<title>someSite | sometitle | anothertitle</title>")
       end
     end
 
-    it 'treats nil as an empty string' do
+    it "treats nil as an empty string" do
       subject.display_meta_tags(title: nil).tap do |meta|
-        expect(meta).not_to have_tag('title')
+        expect(meta).not_to have_tag("title")
       end
     end
 
-    it 'allows objects that respond to #to_str' do
-      title = double(to_str: 'someTitle')
-      subject.display_meta_tags(site: 'someSite', title: title).tap do |meta|
-        expect(meta).to eq('<title>someSite | someTitle</title>')
+    it "allows objects that respond to #to_str" do
+      title = double(to_str: "someTitle")
+      subject.display_meta_tags(site: "someSite", title: title).tap do |meta|
+        expect(meta).to eq("<title>someSite | someTitle</title>")
       end
     end
 
-    it 'fails when title is not a String-like object' do
+    it "fails when title is not a String-like object" do
       skip("Fails RBS") if ENV["RBS_TEST_TARGET"] # rubocop:disable RSpec/Pending
 
       expect {
-        subject.display_meta_tags(site: 'someSite', title: 5)
-      }.to raise_error ArgumentError, 'Expected a string or an object that implements #to_str'
+        subject.display_meta_tags(site: "someSite", title: 5)
+      }.to raise_error ArgumentError, "Expected a string or an object that implements #to_str"
     end
 
-    it 'builds title in reverse order if :reverse' do
+    it "builds title in reverse order if :reverse" do
       subject.display_meta_tags(
-        site:      'someSite',
-        title:     ['someTitle', 'anotherTitle'],
-        prefix:    ' -',
-        suffix:    '+ ',
-        separator: ':',
-        reverse:   true,
+        site: "someSite",
+        title: ["someTitle", "anotherTitle"],
+        prefix: " -",
+        suffix: "+ ",
+        separator: ":",
+        reverse: true
       ).tap do |meta|
-        expect(meta).to eq('<title>anotherTitle -:+ someTitle -:+ someSite</title>')
+        expect(meta).to eq("<title>anotherTitle -:+ someTitle -:+ someSite</title>")
       end
     end
 
-    it 'minifies the output when asked to' do
-      subject.display_meta_tags(title: 'hello', description: 'world').tap do |meta|
+    it "minifies the output when asked to" do
+      subject.display_meta_tags(title: "hello", description: "world").tap do |meta|
         expect(meta).to eq("<title>hello</title>\n<meta name=\"description\" content=\"world\">")
       end
 
       MetaTags.config.minify_output = true
-      subject.display_meta_tags(title: 'hello', description: 'world').tap do |meta|
+      subject.display_meta_tags(title: "hello", description: "world").tap do |meta|
         expect(meta).to eq("<title>hello</title><meta name=\"description\" content=\"world\">")
       end
     end
   end
 
-  describe '.display_title' do
-    it 'displays custom title if given' do
-      subject.title('someTitle')
-      subject.display_title(site: 'someSite', title: 'defaultTitle').tap do |meta|
-        expect(meta).to eq('someSite | someTitle')
+  describe ".display_title" do
+    it "displays custom title if given" do
+      subject.title("someTitle")
+      subject.display_title(site: "someSite", title: "defaultTitle").tap do |meta|
+        expect(meta).to eq("someSite | someTitle")
       end
     end
   end

--- a/spec/view_helper/twitter_spec.rb
+++ b/spec/view_helper/twitter_spec.rb
@@ -1,33 +1,33 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
-RSpec.describe MetaTags::ViewHelper, 'displaying Twitter meta tags' do
-  it 'displays meta tags specified with :twitter' do
+RSpec.describe MetaTags::ViewHelper, "displaying Twitter meta tags" do
+  it "displays meta tags specified with :twitter" do
     subject.set_meta_tags(
       twitter: {
-        title: 'Twitter Share Title',
-        card:  'photo',
+        title: "Twitter Share Title",
+        card: "photo",
         image: {
-          _:      'http://example.com/1.png',
-          width:  123,
-          height: 321,
-        },
-      },
+          _: "http://example.com/1.png",
+          width: 123,
+          height: 321
+        }
+      }
     )
-    subject.display_meta_tags(site: 'someSite').tap do |meta|
-      expect(meta).to have_tag('meta', with: { content: "Twitter Share Title", name: "twitter:title" })
-      expect(meta).to have_tag('meta', with: { content: "photo", name: "twitter:card" })
-      expect(meta).to have_tag('meta', with: { content: "http://example.com/1.png", name: "twitter:image" })
-      expect(meta).to have_tag('meta', with: { content: "123", name: "twitter:image:width" })
-      expect(meta).to have_tag('meta', with: { content: "321", name: "twitter:image:height" })
+    subject.display_meta_tags(site: "someSite").tap do |meta|
+      expect(meta).to have_tag("meta", with: {content: "Twitter Share Title", name: "twitter:title"})
+      expect(meta).to have_tag("meta", with: {content: "photo", name: "twitter:card"})
+      expect(meta).to have_tag("meta", with: {content: "http://example.com/1.png", name: "twitter:image"})
+      expect(meta).to have_tag("meta", with: {content: "123", name: "twitter:image:width"})
+      expect(meta).to have_tag("meta", with: {content: "321", name: "twitter:image:height"})
     end
   end
 
   it "displays mirrored content" do
-    subject.set_meta_tags(title: 'someTitle')
-    subject.display_meta_tags(twitter: { title: :title }).tap do |meta|
-      expect(meta).to have_tag('meta', with: { content: "someTitle", name: "twitter:title" })
+    subject.set_meta_tags(title: "someTitle")
+    subject.display_meta_tags(twitter: {title: :title}).tap do |meta|
+      expect(meta).to have_tag("meta", with: {content: "someTitle", name: "twitter:title"})
     end
   end
 end

--- a/spec/view_helper_spec.rb
+++ b/spec/view_helper_spec.rb
@@ -1,85 +1,85 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe MetaTags::ViewHelper, type: :view_helper do
-  describe 'returning values' do
-    it 'returns headline if specified' do
-      expect(subject.title('some-title', 'some-headline')).to eq('some-headline')
+  describe "returning values" do
+    it "returns headline if specified" do
+      expect(subject.title("some-title", "some-headline")).to eq("some-headline")
     end
 
-    it 'returns title' do
-      expect(subject.title('some-title')).to eq('some-title')
-      expect(subject.title).to eq('some-title')
+    it "returns title" do
+      expect(subject.title("some-title")).to eq("some-title")
+      expect(subject.title).to eq("some-title")
     end
 
-    it 'returns description' do
-      expect(subject.description('some-description')).to eq('some-description')
+    it "returns description" do
+      expect(subject.description("some-description")).to eq("some-description")
     end
 
-    it 'returns keywords' do
-      expect(subject.keywords('some-keywords')).to eq('some-keywords')
+    it "returns keywords" do
+      expect(subject.keywords("some-keywords")).to eq("some-keywords")
     end
 
-    it 'returns noindex' do
-      expect(subject.noindex('some-noindex')).to eq('some-noindex')
+    it "returns noindex" do
+      expect(subject.noindex("some-noindex")).to eq("some-noindex")
     end
 
-    it 'returns nofollow' do
-      expect(subject.noindex('some-nofollow')).to eq('some-nofollow')
+    it "returns nofollow" do
+      expect(subject.noindex("some-nofollow")).to eq("some-nofollow")
     end
   end
 
-  describe 'while handling string meta tag names' do
-    it 'works with common parameters' do
-      subject.display_meta_tags('site' => 'someSite', 'title' => 'someTitle').tap do |meta|
-        expect(meta).to eq('<title>someSite | someTitle</title>')
+  describe "while handling string meta tag names" do
+    it "works with common parameters" do
+      subject.display_meta_tags("site" => "someSite", "title" => "someTitle").tap do |meta|
+        expect(meta).to eq("<title>someSite | someTitle</title>")
       end
     end
 
-    it 'works with open graph parameters' do
+    it "works with open graph parameters" do
       subject.set_meta_tags(
-        'og' => {
-          'title'       => 'facebook title',
-          'description' => 'facebook description',
-        },
+        "og" => {
+          "title" => "facebook title",
+          "description" => "facebook description"
+        }
       )
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).to have_tag('meta', with: { content: "facebook title", property: "og:title" })
-        expect(meta).to have_tag('meta', with: { content: "facebook description", property: "og:description" })
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).to have_tag("meta", with: {content: "facebook title", property: "og:title"})
+        expect(meta).to have_tag("meta", with: {content: "facebook description", property: "og:description"})
       end
     end
 
-    it 'works with app links parameters' do
+    it "works with app links parameters" do
       subject.set_meta_tags(
-        'al' => {
-          'ios' => {
-            'url'          => 'applinks://docs',
-            'app_store_id' => 12_345,
-            'app_name'     => 'App Links',
-          },
-        },
+        "al" => {
+          "ios" => {
+            "url" => "applinks://docs",
+            "app_store_id" => 12_345,
+            "app_name" => "App Links"
+          }
+        }
       )
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).to have_tag('meta', with: { content: "applinks://docs", property: "al:ios:url" })
-        expect(meta).to have_tag('meta', with: { content: "12345", property: "al:ios:app_store_id" })
-        expect(meta).to have_tag('meta', with: { content: "App Links", property: "al:ios:app_name" })
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).to have_tag("meta", with: {content: "applinks://docs", property: "al:ios:url"})
+        expect(meta).to have_tag("meta", with: {content: "12345", property: "al:ios:app_store_id"})
+        expect(meta).to have_tag("meta", with: {content: "App Links", property: "al:ios:app_name"})
       end
     end
 
-    it 'works with facebook parameters' do
+    it "works with facebook parameters" do
       subject.set_meta_tags(
-        'fb' => {
+        "fb" => {
           app_id: 12_345,
-          admins: "12345,23456",
-        },
+          admins: "12345,23456"
+        }
       )
-      subject.display_meta_tags(site: 'someSite').tap do |meta|
-        expect(meta).to have_tag('meta', with: { content: "12345", property: "fb:app_id" })
-        expect(meta).to have_tag('meta', with: { content: "12345,23456", property: "fb:admins" })
+      subject.display_meta_tags(site: "someSite").tap do |meta|
+        expect(meta).to have_tag("meta", with: {content: "12345", property: "fb:app_id"})
+        expect(meta).to have_tag("meta", with: {content: "12345,23456", property: "fb:admins"})
       end
     end
   end
 
-  it_behaves_like '.set_meta_tags'
+  it_behaves_like ".set_meta_tags"
 end


### PR DESCRIPTION
Since its inception, this gem has been using heavily customized Rubocop code style rules, based on my personal preferences and very opinionated view on how Ruby code should look like.

I think it is time to switch to a more community-approved code style, supported by the [standard](https://github.com/testdouble/standard) gem.

As it does not support Rubocop extensions, we will still use Rubocop, but apply standard rules by default (see [RuboCoping with legacy\: Bring your Ruby code up to Standard](https://evilmartians.com/chronicles/rubocoping-with-legacy-bring-your-ruby-code-up-to-standard)).

Edit: Currently, CodeClimate does not have a channel for Rubocop 1.35.1 (required by the current version of the "standard" gem). Also, CodeClimate build does not fail for some reason, but spits out this to the output:

> ```Channel rubocop-1-35-1 not found for rubocop, available channels: ["stable", "beta", "cache-support", "rubocop-0-42", "rubocop-0-46", "rubocop-0-48", "rubocop-0-49", "rubocop-0-50", "rubocop-0-51", "rubocop-0-52", "rubocop-0-54", "rubocop-0-55", "rubocop-0-56", "rubocop-0-57", "rubocop-0-58", "rubocop-0-59", "rubocop-0-60", "rubocop-0-61", "rubocop-0-62", "rubocop-0-63", "rubocop-0-64", "rubocop-0-66", "rubocop-0-65", "rubocop-0-67", "rubocop-0-68", "rubocop-0-69", "rubocop-0-70", "rubocop-0-71", "rubocop-0-72", "rubocop-0-73", "rubocop-0-74", "rubocop-0-75", "rubocop-0-76", "rubocop-0-76-airbnb", "rubocop-0-77", "rubocop-0-78", "rubocop-0-79", "rubocop-0-80", "rubocop-0-81", "rubocop-0-82", "rubocop-0-83", "rubocop-0-84", "rubocop-0-85", "rubocop-0-86", "rubocop-0-87", "rubocop-0-88", "rubocop-0-89", "rubocop-0-90", "rubocop-0-92", "rubocop-1-70", "rubocop-1-7-0", "rubocop-1-8-1", "rubocop-1-9-1", "rubocop-1-10-0", "rubocop-1-11-0", "rubocop-1-12-0", "rubocop-1-12-1", "rubocop-1-18-3", "rubocop-1-20-0", "rubocop-1-21-0", "rubocop-1-22-2", "rubocop-1-22-3", "rubocop-1-23-0", "rubocop-1-30-0", "rubocop-1-31-0"]```