### PR TITLE
Switching gemspec from add_dependency to add_runtime_dependency

### DIFF
--- a/meta-tags.gemspec
+++ b/meta-tags.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "actionpack", ">= 3.2.0", "< 7.1"
+  spec.add_runtime_dependency "actionpack", ">= 3.2.0", "< 7.1"
 
   spec.add_development_dependency "railties", ">= 3.2.0", "< 7.1"
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
There is no difference between the two, but `add_runtime_dependency` is more explicit. Official position is that ... there is no difference https://github.com/rubygems/rubygems/issues/1349.

Rubygems [Specification Reference](https://guides.rubygems.org/specification-reference/) mentions only `add_runtime_dependency`.