### PR TITLE
Switching from Rubocop to Standard completely

### DIFF
--- a/.github/workflows/standard.yml
+++ b/.github/workflows/standard.yml
@@ -1,6 +1,9 @@
 name: StandardRB
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+    types: [opened, reopened]
 env:
   BUNDLE_GEMFILE: gemfiles/rails_7.0.gemfile
 

--- a/.github/workflows/standard.yml
+++ b/.github/workflows/standard.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install gems
         run: |
           bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
+          bundle check || (bundle install --jobs=4 --retry=3 && bundle clean)
       - name: Run StandardRB
         run: |
           bundle exec standardrb

--- a/.github/workflows/standard.yml
+++ b/.github/workflows/standard.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Cache gems
         uses: actions/cache@v3
         with:
-          path: vendor/bundle
+          path: gemfiles/vendor/bundle
           key: ${{ runner.os }}-rubocop-${{ hashFiles('gemfiles/rails_7.0.gemfile') }}
           restore-keys: |
             ${{ runner.os }}-rubocop-
@@ -29,4 +29,5 @@ jobs:
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
       - name: Run StandardRB
-        run: bundle exec standardrb --parallel
+        run: |
+          bundle exec standardrb

--- a/.github/workflows/standard.yml
+++ b/.github/workflows/standard.yml
@@ -1,13 +1,29 @@
 name: StandardRB
 
-on: [push]
+on: [push, pull_request]
+env:
+  BUNDLE_GEMFILE: gemfiles/rails_7.0.gemfile
 
 jobs:
   build:
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v1
-      - name: StandardRB Linter
-        uses: andrewmcodes/standardrb-action@v1.0.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v3
+      - name: Set up Ruby 3.2
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.2.0
+      - name: Cache gems
+        uses: actions/cache@v3
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-rubocop-${{ hashFiles('gemfiles/rails_7.0.gemfile') }}
+          restore-keys: |
+            ${{ runner.os }}-rubocop-
+      - name: Install gems
+        run: |
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+      - name: Run StandardRB
+        run: bundle exec standardrb --parallel

--- a/.rubocop-rails.yml
+++ b/.rubocop-rails.yml
@@ -1,0 +1,17 @@
+require:
+  - rubocop-rails
+
+inherit_gem:
+  rubocop-rails:
+    - config/default.yml
+
+AllCops:
+  TargetRailsVersion: 5.1
+
+# Do not require loading Rails environment for Rake tasks as we are not a Rails application.
+Rails/RakeEnvironment:
+  Enabled: false
+
+# Do not require subclassing from ApplicationController as we're not a rails application
+Rails/ApplicationController:
+  Enabled: false

--- a/.rubocop-rake.yml
+++ b/.rubocop-rake.yml
@@ -1,0 +1,6 @@
+require:
+  - rubocop-rake
+
+inherit_gem:
+  rubocop-rake:
+    - config/default.yml

--- a/.rubocop-rspec.yml
+++ b/.rubocop-rspec.yml
@@ -1,28 +1,9 @@
 require:
-  - standard
-  - rubocop-performance
-  - rubocop-rails
-  - rubocop-rake
   - rubocop-rspec
 
 inherit_gem:
-  standard: config/base.yml
-
-AllCops:
-  # Enable all the rules by default
-  EnabledByDefault: true
-  # Command line rubocop options
-  ExtraDetails: true
-  DisplayStyleGuide: true
-  DisplayCopNames: true
-  SuggestExtensions: false
-  # Target versions
-  TargetRubyVersion: 2.6
-  TargetRailsVersion: 5.1
-
-#-------------------------------------------------------------------------------
-# RSpec rules
-#-------------------------------------------------------------------------------
+  rubocop-rspec:
+    - config/default.yml
 
 RSpec/MultipleExpectations:
   Max: 7
@@ -51,15 +32,3 @@ RSpec/VerifiedDoubles:
 RSpec/NoExpectationExample:
   AllowedPatterns:
     - test_hashes_and_arrays
-
-#-------------------------------------------------------------------------------
-# Disabled rules
-#-------------------------------------------------------------------------------
-
-# Do not require loading Rails enviroment for Rake tasks as we are not a Rails application.
-Rails/RakeEnvironment:
-  Enabled: false
-
-# Do not require subclassing from ApplicationController as we're not a rails application
-Rails/ApplicationController:
-  Enabled: false

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,0 +1,5 @@
+ruby_version: 2.6.0
+extend_config:
+  - .rubocop-rake.yml
+  - .rubocop-rails.yml
+  - .rubocop-rspec.yml

--- a/.standard.yml
+++ b/.standard.yml
@@ -3,3 +3,5 @@ extend_config:
   - .rubocop-rake.yml
   - .rubocop-rails.yml
   - .rubocop-rspec.yml
+ignore:
+  - "gemfiles/vendor/**/*"

--- a/meta-tags.gemspec
+++ b/meta-tags.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "standard", "~> 1.22.0"
   spec.add_development_dependency "rubocop-rails", "~> 2.17.3"
   spec.add_development_dependency "rubocop-rake", "~> 0.6.0"
-  spec.add_development_dependency "rubocop-rspec", "~> 2.17.0"
+  spec.add_development_dependency "rubocop-rspec", "~> 2.18.0"
   # Format RSpec output for CircleCI
   spec.add_development_dependency "rspec_junit_formatter", "~> 0.6.0"
 

--- a/meta-tags.gemspec
+++ b/meta-tags.gemspec
@@ -29,13 +29,12 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.12.0"
   spec.add_development_dependency "rspec-html-matchers", "~> 0.10.0"
   spec.add_development_dependency "appraisal", "~> 2.4.1"
-  spec.add_development_dependency "simplecov", "~> 0.21.2"
+  spec.add_development_dependency "simplecov", "~> 0.22.0"
   # Code style
-  spec.add_development_dependency "standard", "~> 1.18.1"
-  spec.add_development_dependency "rubocop-performance", "~> 1.15.1"
+  spec.add_development_dependency "standard", "~> 1.22.0"
   spec.add_development_dependency "rubocop-rails", "~> 2.17.3"
   spec.add_development_dependency "rubocop-rake", "~> 0.6.0"
-  spec.add_development_dependency "rubocop-rspec", "~> 2.15.0"
+  spec.add_development_dependency "rubocop-rspec", "~> 2.17.0"
   # Format RSpec output for CircleCI
   spec.add_development_dependency "rspec_junit_formatter", "~> 0.6.0"
 

--- a/spec/controller_helper_spec.rb
+++ b/spec/controller_helper_spec.rb
@@ -5,8 +5,8 @@ require "spec_helper"
 RSpec.describe MetaTags::ControllerHelper do
   subject do
     MetaTagsRailsApp::MetaTagsController.new.tap do |c|
-      c.request = ActionDispatch::TestRequest.create
-      c.response = ActionDispatch::TestResponse.new
+      c.set_request! ActionDispatch::TestRequest.create
+      c.set_response! ActionDispatch::TestResponse.new
     end
   end
 

--- a/spec/controller_helper_spec.rb
+++ b/spec/controller_helper_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe MetaTags::ControllerHelper do
   end
 
   before do
-    skip("Does not work properly with RBS") if ENV["RBS_TEST_TARGET"] # rubocop:disable RSpec/Pending
+    skip("Does not work properly with RBS") if ENV["RBS_TEST_TARGET"]
   end
 
   describe "module" do

--- a/spec/support/initialize_rails.rb
+++ b/spec/support/initialize_rails.rb
@@ -17,9 +17,10 @@ module MetaTagsRailsApp
     config.eager_load = false
   end
 
-  class MetaTagsController < ActionController::Base
-    include MetaTags::ControllerHelper
+  # Alright, we're all set. Let's boot!
+  Rails.application.initialize!
 
+  class MetaTagsController < ActionController::Base
     def index
       @page_title = "title"
       @page_keywords = "key1, key2, key3"
@@ -47,6 +48,3 @@ module MetaTagsRailsApp
     include MetaTags::ViewHelper
   end
 end
-
-# Alright, we're all set. Let's boot!
-Rails.application.initialize!

--- a/spec/view_helper/description_spec.rb
+++ b/spec/view_helper/description_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe MetaTags::ViewHelper, "displaying description" do
   end
 
   it "fails when title is not a String-like object" do
-    skip("Fails RBS") if ENV["RBS_TEST_TARGET"] # rubocop:disable RSpec/Pending
+    skip("Fails RBS") if ENV["RBS_TEST_TARGET"]
 
     expect {
       subject.display_meta_tags(description: 5)

--- a/spec/view_helper/title_spec.rb
+++ b/spec/view_helper/title_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe MetaTags::ViewHelper do
     end
 
     it "fails when title is not a String-like object" do
-      skip("Fails RBS") if ENV["RBS_TEST_TARGET"] # rubocop:disable RSpec/Pending
+      skip("Fails RBS") if ENV["RBS_TEST_TARGET"]
 
       expect {
         subject.display_meta_tags(site: "someSite", title: 5)


### PR DESCRIPTION
Since Standard [now supports extensions](https://github.com/testdouble/standard/pull/506), switching completely from Rubocop to Standard.

Edit: of course the [GitHub action](https://github.com/andrewmcodes/standardrb-action) does not support Rubocop extensions. Will need to thing how to deal with this...