### PR TITLE
Addressing compatibility issue with Rails 7.1

### DIFF
--- a/spec/controller_helper_spec.rb
+++ b/spec/controller_helper_spec.rb
@@ -5,8 +5,8 @@ require "spec_helper"
 RSpec.describe MetaTags::ControllerHelper do
   subject do
     MetaTagsRailsApp::MetaTagsController.new.tap do |c|
-      c.request = ActionDispatch::TestRequest.create
-      c.response = ActionDispatch::TestResponse.new
+      c.set_request! ActionDispatch::TestRequest.create
+      c.set_response! ActionDispatch::TestResponse.new
     end
   end
 

--- a/spec/support/initialize_rails.rb
+++ b/spec/support/initialize_rails.rb
@@ -17,9 +17,10 @@ module MetaTagsRailsApp
     config.eager_load = false
   end
 
-  class MetaTagsController < ActionController::Base
-    include MetaTags::ControllerHelper
+  # Alright, we're all set. Let's boot!
+  Rails.application.initialize!
 
+  class MetaTagsController < ActionController::Base
     def index
       @page_title = "title"
       @page_keywords = "key1, key2, key3"
@@ -47,6 +48,3 @@ module MetaTagsRailsApp
     include MetaTags::ViewHelper
   end
 end
-
-# Alright, we're all set. Let's boot!
-Rails.application.initialize!


### PR DESCRIPTION
Fixing a `AbstractController::DoubleRenderError` error happening in tests for Rails 7.1