### PR TITLE
Introduce a new configuration option 'truncate_on_natural_separator' to change or remove natural separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Features:
 
+- Introduced `truncate_on_natural_separator` configuration option to change or disable truncation on natural separator ([283](https://github.com/kpumuk/meta-tags/pull/283)).
 - Introduced `title_tag_attributes` configuration option to add HTML attributes to the title tag ([284](https://github.com/kpumuk/meta-tags/pull/284)).
 
 Changes:

--- a/lib/generators/meta_tags/templates/config/initializers/meta_tags.rb
+++ b/lib/generators/meta_tags/templates/config/initializers/meta_tags.rb
@@ -12,6 +12,9 @@ MetaTags.configure do |config|
   # Add HTML attributes to the <title> HTML tag. Default is {}.
   # config.title_tag_attributes = {}
 
+  # Add HTML attributes to the <title> HTML tag. Default is {}.
+  # config.title_tag_attributes = {}
+
   # Maximum length of the page description. Default is 300.
   # Set to nil or 0 to remove limits.
   # config.description_limit = 300

--- a/lib/meta_tags/configuration.rb
+++ b/lib/meta_tags/configuration.rb
@@ -13,7 +13,7 @@ module MetaTags
     attr_accessor :truncate_site_title_first
 
     # A string or regexp separator to truncate text at a natural break.
-    attr_accessor :truncation_natural_separator
+    attr_accessor :truncate_on_natural_separator
 
     # How many characters to truncate description to.
     attr_accessor :description_limit
@@ -82,7 +82,7 @@ module MetaTags
     def reset_defaults!
       @title_limit = 70
       @truncate_site_title_first = false
-      @truncation_natural_separator = " "
+      @truncate_on_natural_separator = " "
       @title_tag_attributes = {}
       @description_limit = 300
       @keywords_limit = 255

--- a/lib/meta_tags/configuration.rb
+++ b/lib/meta_tags/configuration.rb
@@ -12,6 +12,9 @@ module MetaTags
     # Truncate site_title instead of title.
     attr_accessor :truncate_site_title_first
 
+    # A string or regexp separator to truncate text at a natural break.
+    attr_accessor :truncation_natural_separator
+
     # How many characters to truncate description to.
     attr_accessor :description_limit
 
@@ -79,6 +82,7 @@ module MetaTags
     def reset_defaults!
       @title_limit = 70
       @truncate_site_title_first = false
+      @truncation_natural_separator = " "
       @title_tag_attributes = {}
       @description_limit = 300
       @keywords_limit = 255

--- a/lib/meta_tags/text_normalizer.rb
+++ b/lib/meta_tags/text_normalizer.rb
@@ -142,7 +142,7 @@ module MetaTags
       helpers.truncate(
         string,
         length: limit,
-        separator: MetaTags.config.truncation_natural_separator,
+        separator: MetaTags.config.truncate_on_natural_separator,
         omission: "",
         escape: true
       )

--- a/lib/meta_tags/text_normalizer.rb
+++ b/lib/meta_tags/text_normalizer.rb
@@ -134,16 +134,15 @@ module MetaTags
     #
     # @param [String] string input strings.
     # @param [Integer,nil] limit characters number to truncate to.
-    # @param [String] natural_separator natural separator to truncate at.
     # @return [String] truncated string.
     #
-    def truncate(string, limit = nil, natural_separator = " ")
+    def truncate(string, limit = nil)
       return string if limit.to_i == 0
 
       helpers.truncate(
         string,
         length: limit,
-        separator: natural_separator,
+        separator: MetaTags.config.truncation_natural_separator,
         omission: "",
         escape: true
       )
@@ -154,10 +153,9 @@ module MetaTags
     # @param [Array<String>] string_array input strings.
     # @param [Integer,nil] limit characters number to truncate to.
     # @param [String] separator separator that will be used to join array later.
-    # @param [String] natural_separator natural separator to truncate at.
     # @return [Array<String>] truncated array of strings.
     #
-    def truncate_array(string_array, limit = nil, separator = "", natural_separator = " ")
+    def truncate_array(string_array, limit = nil, separator = "")
       return string_array if limit.nil? || limit <= 0
 
       length = 0
@@ -167,7 +165,7 @@ module MetaTags
         limit_left = calculate_limit_left(limit, length, result, separator)
 
         if string.length > limit_left
-          result << truncate(string, limit_left, natural_separator)
+          result << truncate(string, limit_left)
           break string_array
         end
 

--- a/sig/lib/meta_tags/configuration.rbs
+++ b/sig/lib/meta_tags/configuration.rbs
@@ -7,6 +7,7 @@ module MetaTags
 
     attr_accessor title_limit: Integer?
     attr_accessor truncate_site_title_first: bool
+    attr_accessor truncation_natural_separator: String?|Regexp
     attr_accessor title_tag_attributes: Hash[html_tag_key, html_tag_value]?
     attr_accessor description_limit: Integer
     attr_accessor keywords_limit: Integer

--- a/sig/lib/meta_tags/configuration.rbs
+++ b/sig/lib/meta_tags/configuration.rbs
@@ -7,7 +7,7 @@ module MetaTags
 
     attr_accessor title_limit: Integer?
     attr_accessor truncate_site_title_first: bool
-    attr_accessor truncation_natural_separator: String?|Regexp
+    attr_accessor truncate_on_natural_separator: String?|Regexp
     attr_accessor title_tag_attributes: Hash[html_tag_key, html_tag_value]?
     attr_accessor description_limit: Integer
     attr_accessor keywords_limit: Integer

--- a/sig/lib/meta_tags/text_normalizer.rbs
+++ b/sig/lib/meta_tags/text_normalizer.rbs
@@ -21,9 +21,9 @@ module MetaTags
 
     def cleanup_strings: (keywords? strings, ?strip: bool strip) -> Array[String]
 
-    def truncate: (String string, ?Integer? limit, ?String natural_separator) -> String
+    def truncate: (String string, ?Integer? limit) -> String
 
-    def truncate_array: (Array[String] string_array, ?Integer? limit, ?String separator, ?String natural_separator) -> Array[String]
+    def truncate_array: (Array[String] string_array, ?Integer? limit, ?String separator) -> Array[String]
 
     private
 

--- a/spec/text_normalizer/normalize_description_spec.rb
+++ b/spec/text_normalizer/normalize_description_spec.rb
@@ -3,19 +3,44 @@
 require "spec_helper"
 
 RSpec.describe MetaTags::TextNormalizer, ".normalize_description" do
-  describe "description limit setting" do
-    let(:description) { "d" * (MetaTags.config.description_limit + 10) }
+  let(:description) { "d" * (MetaTags.config.description_limit + 10) }
 
-    it "truncates description when limit is reached" do
-      expect(subject.normalize_description(description)).to eq("d" * MetaTags.config.description_limit)
+  it "truncates description when limit is reached" do
+    expect(subject.normalize_description(description)).to eq("d" * MetaTags.config.description_limit)
+  end
+
+  it "does not truncate description when limit is 0 or nil" do
+    MetaTags.config.description_limit = 0
+    expect(subject.normalize_description(description)).to eq(description)
+
+    MetaTags.config.title_limit = nil
+    expect(subject.normalize_description(description)).to eq(description)
+  end
+
+  context "with text in Japanese" do
+    let(:description) do
+      "Microsoft Copilotは、あなたの言葉をパワフルなコンテンツに変える AI アシスタントです。あなたのニーズに合わせて、文章を生成、要約、編集、変換したり、コードや詩などの創造的なコンテンツを作成したりします。"
     end
 
-    it "does not truncate description when limit is 0 or nil" do
-      MetaTags.config.description_limit = 0
-      expect(subject.normalize_description(description)).to eq(description)
+    before do
+      MetaTags.config.description_limit = 50
+    end
 
-      MetaTags.config.title_limit = nil
-      expect(subject.normalize_description(description)).to eq(description)
+    context "when natural separator has default value" do
+      it "truncates description on space character" do
+        expect(subject.normalize_description(description))
+          .to eq("Microsoft Copilotは、あなたの言葉をパワフルなコンテンツに変える AI")
+      end
+    end
+
+    context "when natural separator is set to nil" do
+      before do
+        MetaTags.config.truncation_natural_separator = nil
+      end
+
+      it "truncates description on unicode codepoint" do
+        expect(subject.normalize_description(description)).to eq(description[0, 50])
+      end
     end
   end
 end

--- a/spec/text_normalizer/normalize_description_spec.rb
+++ b/spec/text_normalizer/normalize_description_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe MetaTags::TextNormalizer, ".normalize_description" do
 
     context "when natural separator is set to nil" do
       before do
-        MetaTags.config.truncation_natural_separator = nil
+        MetaTags.config.truncate_on_natural_separator = nil
       end
 
       it "truncates description on unicode codepoint" do

--- a/spec/text_normalizer/normalize_title_spec.rb
+++ b/spec/text_normalizer/normalize_title_spec.rb
@@ -122,4 +122,31 @@ RSpec.describe MetaTags::TextNormalizer, ".normalize_title" do
       expect(subject.normalize_title(site_title, title, "-")).to eq("#{site_title}-#{title}")
     end
   end
+
+  context "with text in Japanese" do
+    let(:title) do
+      "Microsoft Copilotは、あなたの言葉をパワフルなコンテンツに変える AI アシスタントです。あなたのニーズに合わせて、文章を生成、要約、編集、変換したり、コードや詩などの創造的なコンテンツを作成したりします。"
+    end
+
+    before do
+      MetaTags.config.title_limit = 50
+    end
+
+    context "when natural separator has default value" do
+      it "truncates description on space character" do
+        expect(subject.normalize_title(nil, title, "-"))
+          .to eq("Microsoft Copilotは、あなたの言葉をパワフルなコンテンツに変える AI")
+      end
+    end
+
+    context "when natural separator is set to nil" do
+      before do
+        MetaTags.config.truncation_natural_separator = nil
+      end
+
+      it "truncates description on unicode codepoint" do
+        expect(subject.normalize_title(nil, title, "-")).to eq(title[0, 50])
+      end
+    end
+  end
 end

--- a/spec/text_normalizer/normalize_title_spec.rb
+++ b/spec/text_normalizer/normalize_title_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe MetaTags::TextNormalizer, ".normalize_title" do
 
     context "when natural separator is set to nil" do
       before do
-        MetaTags.config.truncation_natural_separator = nil
+        MetaTags.config.truncate_on_natural_separator = nil
       end
 
       it "truncates description on unicode codepoint" do

--- a/spec/text_normalizer/truncate_array_spec.rb
+++ b/spec/text_normalizer/truncate_array_spec.rb
@@ -59,4 +59,27 @@ RSpec.describe MetaTags::TextNormalizer, ".truncate_array" do
       expect(subject.truncate_array(arr, 7, "-")).to eq(%w[a aa])
     end
   end
+
+  context "with text in Japanese" do
+    let(:title) do
+      "Microsoft Copilotは、あなたの言葉をパワフルなコンテンツに変える AI アシスタントです。あなたのニーズに合わせて、文章を生成、要約、編集、変換したり、コードや詩などの創造的なコンテンツを作成したりします。"
+    end
+
+    context "when natural separator has default value" do
+      it "truncates description on space character" do
+        expect(subject.truncate_array([title], 50))
+          .to eq(["Microsoft Copilotは、あなたの言葉をパワフルなコンテンツに変える AI"])
+      end
+    end
+
+    context "when natural separator is set to nil" do
+      before do
+        MetaTags.config.truncation_natural_separator = nil
+      end
+
+      it "truncates description on unicode codepoint" do
+        expect(subject.truncate_array([title], 50)).to eq([title[0, 50]])
+      end
+    end
+  end
 end

--- a/spec/text_normalizer/truncate_array_spec.rb
+++ b/spec/text_normalizer/truncate_array_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe MetaTags::TextNormalizer, ".truncate_array" do
 
     context "when natural separator is set to nil" do
       before do
-        MetaTags.config.truncation_natural_separator = nil
+        MetaTags.config.truncate_on_natural_separator = nil
       end
 
       it "truncates description on unicode codepoint" do


### PR DESCRIPTION
With this change a new configuration setting is introduced: `truncate_on_natural_separator` can be used to change the natural separator from the default value of `" "` (space character) to another value or `nil` to disable natural separator. This also allows to use a whitespace regular expression (`/\s/`), a unicode space (`/\p{Space}/`).

Closes #281