### PR TITLE
Remove meta-tags.gemspec and Rakefile from the gem package

### DIFF
--- a/meta-tags.gemspec
+++ b/meta-tags.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.0.0"
 
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(\.|Gemfile|Appraisals|Steepfile|(bin|spec|gemfiles)/)})
+    f.match(%r{^(\.|Gemfile|Appraisals|Steepfile|Rakefile|meta-tags.gemspec|(bin|spec|gemfiles)/)})
   end
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }


### PR DESCRIPTION
Bunlding gemspec does not make much sense since it is only used in development to produce metadata, added to the gem package as a YAML-serialized `Gem::Specification`. Additionally, `Rakefile` is also removed, as it is only used in development.

## File list difference

To test, I built the gem with rake build and compared the listing before and after the change:

```bash
tar -xOzf pkg/meta-tags-2.22.0.gem data.tar.gz | tar -tzf -
```

Full diff:

```diff
--- before.txt	2024-09-13 20:39:38
+++ after.txt	2024-09-13 20:39:29
@@ -3,7 +3,6 @@
 CONTRIBUTING.md
 MIT-LICENSE
 README.md
-Rakefile
 certs/kpumuk.pem
 lib/generators/meta_tags/install_generator.rb
 lib/generators/meta_tags/templates/config/initializers/meta_tags.rb
@@ -19,7 +18,6 @@
 lib/meta_tags/text_normalizer.rb
 lib/meta_tags/version.rb
 lib/meta_tags/view_helper.rb
-meta-tags.gemspec
 sig/lib/_internal/rails.rbs
 sig/lib/meta_tags.rbs
 sig/lib/meta_tags/configuration.rbs
```