### PR TITLE
Moved gem private key to secrets to avoid secrets leaking

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,10 +2,6 @@ name: Release
 
 on:
   workflow_dispatch:
-    inputs:
-      passphrase:
-        description: "Private key passphrase for signing the gem"
-        required: true
 
 jobs:
   push:
@@ -39,4 +35,4 @@ jobs:
           echo "${GEM_PRIVATE_KEY}" > ~/.gem/gem-private_key.pem
       - uses: rubygems/release-gem@v1
         env:
-          GEM_PRIVATE_KEY_PASSPHRASE: "${{ inputs.passphrase }}"
+          GEM_PRIVATE_KEY_PASSPHRASE: "${{ secrets.GEM_PRIVATE_KEY_PASSPHRASE }}"


### PR DESCRIPTION
Turns out, using workflow inputs for a secret key was a [bad idea](https://github.com/kpumuk/meta-tags/actions/runs/10967601564/job/30457610286):

```
Run rubygems/release-gem@v1
  with:
    await-release: true
    setup-trusted-publisher: true
  env:
    BUNDLE_GEMFILE: /home/runner/work/meta-tags/meta-tags/gemfiles/rails_7.1.gemfile
    GEM_PRIVATE_KEY_PASSPHRASE: Testing
```