### PR TITLE
Rails 8 will require Ruby 3.2.0 or newer.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,12 +25,14 @@ jobs:
           - "edge"
         include:
           - ruby-version: "3.3"
-            rails-version: "7.1"
+            rails-version: "7.2"
             code-coverage: true
         exclude:
           - ruby-version: "3.0"
             rails-version: "7.2"
           - ruby-version: "3.0"
+            rails-version: "edge"
+          - ruby-version: "3.1"
             rails-version: "edge"
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/rails_${{ matrix.rails-version }}.gemfile


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/53041