### PR TITLE
Keep canonical links for empty noindex target lists

### DIFF
--- a/lib/meta_tags/meta_tags_collection.rb
+++ b/lib/meta_tags/meta_tags_collection.rb
@@ -164,6 +164,13 @@ module MetaTags
       result.transform_values { |v| v.join(", ") }
     end
 
+    # Returns whether noindex settings produce at least one robots directive.
+    #
+    # @return [Boolean] true when a noindex directive will be rendered.
+    def noindex?
+      robots_attribute_present?(meta_tags[:noindex])
+    end
+
     protected
 
     # Converts input hash to HashWithIndifferentAccess and renames :open_graph to :og.
@@ -193,9 +200,17 @@ module MetaTags
     def extract_robots_attribute(name)
       noindex = extract(name)
       noindex_name = (noindex.is_a?(String) || noindex.is_a?(Array)) ? noindex : "robots"
-      noindex_value = noindex ? name.to_s : nil
+      noindex_value = robots_attribute_present?(noindex) ? name.to_s : nil
 
       [noindex_name, noindex_value]
+    end
+
+    # Returns whether a robots attribute resolves to at least one target.
+    #
+    # @param value [Object] robots attribute value.
+    # @return [Boolean] true when the attribute produces a directive.
+    def robots_attribute_present?(value)
+      !!value && (!value.is_a?(Array) || !value.empty?)
     end
 
     # Appends resolved robots directives while preserving first-write priority.

--- a/lib/meta_tags/renderer.rb
+++ b/lib/meta_tags/renderer.rb
@@ -160,7 +160,7 @@ module MetaTags
     # @param tags [Array<Tag>] a buffer object to store tags in.
     def render_canonical_link(tags)
       href = meta_tags.extract(:canonical) # extract, so it's not used anywhere else
-      return if MetaTags.config.skip_canonical_links_on_noindex && meta_tags[:noindex]
+      return if MetaTags.config.skip_canonical_links_on_noindex && meta_tags.noindex?
       return if href.blank?
 
       @normalized_meta_tags[:canonical] = href

--- a/sig/lib/meta_tags/meta_tags_collection.rbs
+++ b/sig/lib/meta_tags/meta_tags_collection.rbs
@@ -28,11 +28,15 @@ module MetaTags
 
     def extract_robots: () -> Hash[String, String]
 
+    def noindex?: () -> bool
+
     def normalize_open_graph: (Hash[String | Symbol, untyped] meta_tags) -> ActiveSupport::HashWithIndifferentAccess[String | Symbol, untyped]
 
     def extract_separator_section: (String | Symbol name, String default) -> String
 
     def extract_robots_attribute: (String | Symbol name) -> [String | Array[String | Symbol], String?]
+
+    def robots_attribute_present?: (untyped value) -> bool
 
     def calculate_robots_attributes: (Hash[String, Array[String]] result, String | Symbol | Array[String | Symbol] attributes) -> void
 

--- a/spec/view_helper/links_spec.rb
+++ b/spec/view_helper/links_spec.rb
@@ -45,11 +45,31 @@ RSpec.describe MetaTags::ViewHelper do
         end
       end
 
-      it "does not display canonical url when page is marked as noindex" do
-        subject.set_meta_tags(canonical: "http://example.com/base/url", noindex: true)
-        subject.display_meta_tags(site: "someSite").tap do |meta|
-          expect(meta).not_to have_tag("link", with: {href: "http://example.com/base/url", rel: "canonical"})
-          expect(meta).not_to have_tag("meta", with: {content: "http://example.com/base/url", name: "canonical"})
+      [
+        ["nil", nil, []],
+        ["false", false, []],
+        ["an empty crawler list", [], []],
+        ["true", true, ["robots"]],
+        ["a scalar crawler", "googlebot", ["googlebot"]],
+        ["a nonempty crawler list", ["googlebot", "bingbot"], ["googlebot", "bingbot"]]
+      ].each do |description, noindex, robots_names|
+        it "keeps canonical and robots output aligned for #{description}" do
+          subject.set_meta_tags(canonical: "http://example.com/base/url", noindex: noindex)
+          subject.display_meta_tags(site: "someSite").tap do |meta|
+            if robots_names.empty?
+              expect(meta).not_to have_tag("meta", with: {content: "noindex"})
+              expect(meta).to have_tag("link", with: {href: "http://example.com/base/url", rel: "canonical"})
+              next
+            end
+
+            expect(meta).to have_tag("meta", count: robots_names.size, with: {content: "noindex"})
+
+            robots_names.each do |name|
+              expect(meta).to have_tag("meta", with: {content: "noindex", name: name})
+            end
+
+            expect(meta).not_to have_tag("link", with: {href: "http://example.com/base/url", rel: "canonical"})
+          end
         end
       end
     end


### PR DESCRIPTION
When `skip_canonical_links_on_noindex` was enabled, canonical rendering checked the raw Ruby truthiness of `noindex`. An empty crawler list therefore suppressed the canonical link even though robots rendering emitted no directive.

```ruby
MetaTags.config.skip_canonical_links_on_noindex = true

collection = MetaTags::MetaTagsCollection.new
collection.update(
  noindex: [],
  canonical: "https://example.test/page"
)

MetaTags::Renderer
  .new(collection)
  .render(ActionController::Base.helpers)
```

Before:

```html
""
```

After:

```html
<link rel="canonical" href="https://example.test/page">
```

The change centralizes semantic robots-attribute detection in `MetaTagsCollection` and makes canonical suppression use that non-mutating result. It preserves existing behavior for `true`, scalar crawlers, and every nonempty crawler array without coupling canonical rendering to robots extraction order.
