### PR TITLE
Preserve legacy custom robots values and valueless directives

### DIFF
--- a/lib/meta_tags/meta_tags_collection.rb
+++ b/lib/meta_tags/meta_tags_collection.rb
@@ -155,9 +155,15 @@ module MetaTags
       end
 
       [:robots, :googlebot, :bingbot].each do |bot|
-        values = extract(bot).presence
-        if values
-          result[bot.to_s].concat(values.map { |k, v| "#{k}:#{v}" })
+        values = meta_tags[bot]
+        next unless values.is_a?(Hash)
+
+        extract(bot)
+        values.each do |key, value|
+          next if value == false
+
+          directive = (value.nil? || value == true) ? key.to_s : "#{key}:#{value}"
+          result[bot.to_s] << directive
         end
       end
 

--- a/spec/view_helper/robots_spec.rb
+++ b/spec/view_helper/robots_spec.rb
@@ -3,6 +3,35 @@
 require "spec_helper"
 
 RSpec.describe MetaTags::ViewHelper, "displaying robots meta tags" do
+  [:robots, :googlebot, :bingbot].each do |bot|
+    it "preserves scalar custom values for :#{bot}" do
+      expect(subject.display_meta_tags(bot => "noindex, nofollow, nojokes"))
+        .to eq(%(<meta name="#{bot}" content="noindex, nofollow, nojokes">))
+    end
+
+    it "preserves array custom values for :#{bot}" do
+      expect(subject.display_meta_tags(bot => ["noindex", "nofollow"]))
+        .to eq(<<~HTML.chomp)
+          <meta name="#{bot}" content="noindex">
+          <meta name="#{bot}" content="nofollow">
+        HTML
+    end
+  end
+
+  it "renders valued and valueless directives while omitting disabled directives" do
+    expect(
+      subject.display_meta_tags(
+        robots: {indexifembedded: nil, "max-snippet": -1, nosnippet: false},
+        googlebot: {nosnippet: true, unavailable_after: "2026-12-31", noimageindex: false},
+        bingbot: {noimageindex: nil, "max-image-preview": "large", nosnippet: false}
+      )
+    ).to eq(<<~HTML.chomp)
+      <meta name="robots" content="indexifembedded, max-snippet:-1">
+      <meta name="googlebot" content="nosnippet, unavailable_after:2026-12-31">
+      <meta name="bingbot" content="noimageindex, max-image-preview:large">
+    HTML
+  end
+
   it "displays meta tags specified with :robots" do
     subject.display_meta_tags(robots: {"max-snippet": -1}).tap do |meta|
       expect(meta).to have_tag("meta", with: {content: "max-snippet:-1", name: "robots"})
@@ -29,15 +58,13 @@ RSpec.describe MetaTags::ViewHelper, "displaying robots meta tags" do
 
   it "displays custom robots tags along with noindex" do
     subject.noindex(true)
-    subject.display_meta_tags(robots: {"max-snippet": -1, "max-video-preview": -1}).tap do |meta|
-      expect(meta).to have_tag("meta", with: {content: "noindex, max-snippet:-1, max-video-preview:-1", name: "robots"})
-    end
+    expect(subject.display_meta_tags(robots: {"max-snippet": -1, "max-video-preview": -1}))
+      .to eq('<meta name="robots" content="noindex, max-snippet:-1, max-video-preview:-1">')
   end
 
   it "merges bot-specific directives with helper-based robots directives" do
     subject.set_meta_tags(noindex: "googlebot", googlebot: {unavailable_after: "2026-12-31"})
-    subject.display_meta_tags.tap do |meta|
-      expect(meta).to have_tag("meta", with: {content: "noindex, unavailable_after:2026-12-31", name: "googlebot"})
-    end
+    expect(subject.display_meta_tags)
+      .to eq('<meta name="googlebot" content="noindex, unavailable_after:2026-12-31">')
   end
 end


### PR DESCRIPTION
Custom robots serialization assumed every `robots`, `googlebot`, and `bingbot` value was a hash. That broke the established scalar and array custom-tag contract, including the scalar `googlebot` form documented in issue #234. It also interpolated every hash value after a colon, producing invalid tokens for valueless and disabled directives.

The specialized path now consumes hashes only, leaving scalar and array values to the existing generic renderer. Within hashes, `nil` and `true` enable a bare directive, `false` disables it, and other values retain `key:value` serialization.

### Rendering changes

A legacy scalar value previously raised an exception:

```ruby
set_meta_tags googlebot: "noindex, nofollow, nojokes"
```

Before:

```text
NoMethodError: undefined method `map' for an instance of String
```

After:

```html
<meta name="googlebot" content="noindex, nofollow, nojokes">
```

Array values now retain the previous one-tag-per-item behavior:

```ruby
set_meta_tags bingbot: ["nosnippet", "noimageindex"]
```

Before:

```html
<meta name="bingbot" content="nosnippet:, noimageindex:">
```

After:

```html
<meta name="bingbot" content="nosnippet">
<meta name="bingbot" content="noimageindex">
```

Valueless and disabled hash directives are normalized explicitly:

```ruby
set_meta_tags robots: {
  indexifembedded: nil,
  nosnippet: true,
  noimageindex: false,
  "max-snippet": -1
}
```

Before:

```html
<meta name="robots" content="indexifembedded:, nosnippet:true, noimageindex:false, max-snippet:-1">
```

After:

```html
<meta name="robots" content="indexifembedded, nosnippet, max-snippet:-1">
```

Valued directives and helper merging remain compatible:

```ruby
set_meta_tags noindex: true, robots: {"max-snippet": -1}
```

Before and after:

```html
<meta name="robots" content="noindex, max-snippet:-1">
```

Exact-output regressions cover `robots`, `googlebot`, and `bingbot`, including scalar and array rendering, valued and valueless directives, disabled entries, and helper-generated directives. The focused suite, complete tracked RSpec suite, runtime RBS suite, StandardRB, and diff checks pass.
