### PR TITLE
Propagate Steep failures and reconcile RBS signatures

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,6 +17,11 @@ module SteepRunner
 
     Steep::CLI.new(argv: command, stdout: $stdout, stderr: $stderr, stdin: $stdin).run
   end
+
+  def self.run!(*command)
+    status = run(*command)
+    raise "Steep exited with status #{status}" unless status.zero?
+  end
 end
 
 desc "Check type information"
@@ -25,12 +30,12 @@ task steep: "steep:check"
 namespace :steep do
   desc "Check type information"
   task :check do
-    SteepRunner.run("check")
+    SteepRunner.run!("check")
   end
 
   desc "Print type statistics"
   task :stats do
-    SteepRunner.run("stats", "--log-level=fatal")
+    SteepRunner.run!("stats", "--log-level=fatal")
   end
 end
 

--- a/sig/lib/meta_tags/renderer.rbs
+++ b/sig/lib/meta_tags/renderer.rbs
@@ -31,20 +31,22 @@ module MetaTags
 
     def render_canonical_link: (Array[Tag] tags) -> void
 
-    def render_hashes: (Array[Tag] tags, **untyped opts) -> void
+    def render_hashes: (Array[Tag] tags) -> void
 
-    def render_hash: (Array[Tag] tags, untyped key, **untyped opts) -> void
+    def render_hash: (Array[Tag] tags, meta_key key) -> void
 
     def render_custom: (Array[Tag] tags) -> void
 
-    def process_tree: (Array[Tag] tags, meta_key property, meta_value content, ?itemprop: meta_key? itemprop, **untyped opts) -> void
+    def process_tree: (Array[Tag] tags, meta_key property, meta_value content, ?itemprop: meta_value itemprop) -> void
 
-    def process_hash: (Array[Tag] tags, meta_key property, Hash[meta_key, meta_value] content, **untyped opts) -> void
+    def process_hash: (Array[Tag] tags, meta_key property, Hash[meta_key, meta_value] content, ?itemprop: meta_value itemprop) -> void
 
-    def process_array: (Array[Tag] tags, meta_key property, Array[meta_value] content, **untyped opts) -> void
+    def process_array: (Array[Tag] tags, meta_key property, Array[meta_value] content, ?itemprop: meta_value itemprop) -> void
 
-    def render_tag: (Array[Tag] tags, meta_key name, meta_content value, ?itemprop: meta_key? itemprop) -> void
+    def render_tag: (Array[Tag] tags, meta_key name, meta_content value, ?itemprop: meta_value itemprop) -> void
 
     def configured_name_key: (meta_key name) -> Symbol
+
+    def property_tag?: (String name, String tag_name) -> bool
   end
 end

--- a/sig/lib/meta_tags/tag.rbs
+++ b/sig/lib/meta_tags/tag.rbs
@@ -7,6 +7,6 @@ module MetaTags
 
     def render: (_ActionViewBase view) -> String
 
-    def prepare_attributes: (Hash[String | Symbol, untyped] attributes) -> Hash[String | Symbol, untyped]
+    def serialize_iso8601_attributes: (Hash[String | Symbol, untyped] attributes) -> Hash[String | Symbol, untyped]
   end
 end

--- a/spec/rakefile_spec.rb
+++ b/spec/rakefile_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rake"
+
+load File.expand_path("../Rakefile", __dir__)
+
+RSpec.describe SteepRunner do
+  it "fails when Steep returns a nonzero status" do
+    allow(described_class).to receive(:run).with("check").and_return(1)
+
+    expect { Rake::Task["steep"].invoke }
+      .to raise_error(RuntimeError, "Steep exited with status 1")
+  end
+end


### PR DESCRIPTION
### Why?

The CI type-checking task invoked `Steep::CLI` in-process but ignored its integer exit status. As a result, `bundle exec rake steep` reported eleven type errors while still exiting successfully.

The signature drift came from source changes rather than an RBS or Steep update. Commit [`3b582a2`](https://github.com/kpumuk/meta-tags/commit/3b582a262fa7388f71ac3981645d4c4197d53c33) introduced `property_tag?` without declaring it. Commit [`f099110`](https://github.com/kpumuk/meta-tags/commit/f099110f416a79aaa1b9a080a35bbf17522ff8fa) renamed `prepare_attributes` to `serialize_iso8601_attributes`, removed permissive keyword arguments from Renderer helpers, and changed how `itemprop` flows through the renderer. Replaying the surrounding snapshots with the current Steep 1.10.0 and RBS 3.10.4 toolchain confirmed that those commits introduced exactly two and then eleven errors.

### How?

Make the Rake wrapper fail on nonzero Steep statuses, align the signatures with the current Ruby contracts, and cover the workflow-facing task with a deterministic regression. An intentional signature mismatch confirmed that direct Steep and the Rake wrapper both exit nonzero; with valid signatures, static and runtime type checks agree.

### Compatibility

The signature corrections do not change rendering behavior. Unknown meta-tag, nested, and HTML attribute keys remain supported when expressed as strings or symbols, and attribute values remain untyped. Removing `**untyped` only stops the signatures from claiming that protected Renderer helpers accept arbitrary keywords—the Ruby methods already reject them.

RBS-aware code relying on the stale protected-method declarations may now receive an accurate type error for behavior that already fails at runtime. Existing supported calls, including custom keys and `itemprop` values, remain valid.
