### PR TITLE
Deprecate ambiguous array symbols with an opt-in 3.0 mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,19 @@ either partially truncate the last item or stop at item boundaries. Set
 `config.truncate_array_items_at_boundaries = true` to preserve whole items for
 multi-item arrays. Single-item arrays are still truncated normally.
 
+Symbols in nested custom tag arrays are literal values in MetaTags 2.x.
+MetaTags 3.0 will use them to look up normalized top-level tags. You can turn
+on this behavior now:
+
+```ruby
+MetaTags.configure do |config|
+  config.resolve_symbolic_references_in_arrays = true
+end
+```
+
+When this option is on, use Strings for literal array values. MetaTags does not
+render a tag when a Symbol has no match.
+
 By default, meta tags are rendered with the key `name`. However, some meta tags are required to use `property` instead (like Facebook Open Graph object). The MetaTags gem allows you to configure which tags to render with the `property` attribute. The pre-configured list includes all possible Facebook Open Graph object types by default, but you can add your own in case you need it.
 
 ## MetaTags Usage

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ multi-item arrays. Single-item arrays are still truncated normally.
 
 Symbols in nested custom tag arrays are literal values in MetaTags 2.x.
 MetaTags 3.0 will use them to look up normalized top-level tags. You can turn
-on this behavior now:
+on this behavior now. Until then, each nested array that contains a direct
+Symbol value emits a deprecation warning:
 
 ```ruby
 MetaTags.configure do |config|

--- a/lib/generators/meta_tags/templates/config/initializers/meta_tags.rb
+++ b/lib/generators/meta_tags/templates/config/initializers/meta_tags.rb
@@ -43,6 +43,11 @@ MetaTags.configure do |config|
   # Default is false.
   # config.minify_output = false
 
+  # When true, Symbols inside nested meta tag arrays resolve as references to
+  # normalized top-level tags. Default is false until MetaTags 3.0, when this
+  # behavior will become the default.
+  # config.resolve_symbolic_references_in_arrays = false
+
   # When false, generated meta tags will be self-closing (<meta ... />) instead
   # of open (`<meta ...>`). Default is true.
   # config.open_meta_tags = true

--- a/lib/meta_tags.rb
+++ b/lib/meta_tags.rb
@@ -2,12 +2,18 @@
 
 require "set"
 require "active_support/core_ext/hash/indifferent_access"
+require "active_support/deprecation"
 
 # MetaTags gem namespace.
 module MetaTags
   # Returns MetaTags gem configuration.
   def self.config
     @config ||= Configuration.new
+  end
+
+  # Returns the deprecator used for MetaTags API warnings.
+  def self.deprecator
+    @deprecator ||= ActiveSupport::Deprecation.new("3.0", "MetaTags")
   end
 
   # Configures MetaTags gem.

--- a/lib/meta_tags/configuration.rb
+++ b/lib/meta_tags/configuration.rb
@@ -39,6 +39,10 @@ module MetaTags
     # Default is false.
     attr_accessor :minify_output
 
+    # When true, Symbols inside nested meta tag arrays resolve as references to
+    # normalized top-level tags. Default is false until MetaTags 3.0.
+    attr_accessor :resolve_symbolic_references_in_arrays
+
     # Custom meta tags that should use the `property` attribute instead of `name`.
     # An array of strings or symbols representing their names or name prefixes.
     attr_reader :property_tags
@@ -107,6 +111,7 @@ module MetaTags
       @property_tags = default_property_tags.dup
       @open_meta_tags = true
       @minify_output = false
+      @resolve_symbolic_references_in_arrays = false
       @skip_canonical_links_on_noindex = false
     end
   end

--- a/lib/meta_tags/railtie.rb
+++ b/lib/meta_tags/railtie.rb
@@ -3,6 +3,10 @@
 module MetaTags
   # Hooks MetaTags helpers into Rails controllers and views.
   class Railtie < Rails::Railtie
+    initializer "meta_tags.register_deprecator", before: :load_environment_config do |app|
+      app.deprecators[:meta_tags] = MetaTags.deprecator if app.respond_to?(:deprecators)
+    end
+
     initializer "meta_tags.setup_action_controller" do
       ActiveSupport.on_load :action_controller do
         include MetaTags::ControllerHelper

--- a/lib/meta_tags/renderer.rb
+++ b/lib/meta_tags/renderer.rb
@@ -239,12 +239,11 @@ module MetaTags
           next_itemprop = nil
         end
 
-        normalized_value = if value.is_a?(Symbol)
-          normalized_meta_tags[value]
+        if value.is_a?(Symbol)
+          process_reference(tags, key, value, itemprop: next_itemprop)
         else
-          value
+          process_tree(tags, key, value, itemprop: next_itemprop)
         end
-        process_tree(tags, key, normalized_value, itemprop: next_itemprop)
       end
     end
 
@@ -256,9 +255,7 @@ module MetaTags
     # @param itemprop [String, Symbol, nil] value of the itemprop attribute.
     def process_array(tags, property, content, itemprop: nil)
       unless MetaTags.config.resolve_symbolic_references_in_arrays
-        symbol_reference = content.find do |value|
-          value.is_a?(Symbol) && normalized_meta_tags.key?(value)
-        end
+        symbol_reference = content.find { |value| value.is_a?(Symbol) }
         if symbol_reference
           MetaTags.deprecator.warn(
             "Passing #{symbol_reference.inspect} directly inside a nested meta tag Array is deprecated. " \

--- a/lib/meta_tags/renderer.rb
+++ b/lib/meta_tags/renderer.rb
@@ -214,7 +214,11 @@ module MetaTags
       when Array
         process_array(tags, property, content, itemprop: itemprop)
       else
-        render_tag(tags, property, content, itemprop: itemprop)
+        if content.is_a?(Symbol) && MetaTags.config.resolve_symbolic_references_in_arrays
+          process_reference(tags, property, content, itemprop: itemprop)
+        else
+          render_tag(tags, property, content, itemprop: itemprop)
+        end
       end
     end
 
@@ -251,7 +255,39 @@ module MetaTags
     # @param content [Array] array of nested meta tag attributes or values.
     # @param itemprop [String, Symbol, nil] value of the itemprop attribute.
     def process_array(tags, property, content, itemprop: nil)
+      unless MetaTags.config.resolve_symbolic_references_in_arrays
+        symbol_reference = content.find do |value|
+          value.is_a?(Symbol) && normalized_meta_tags.key?(value)
+        end
+        if symbol_reference
+          MetaTags.deprecator.warn(
+            "Passing #{symbol_reference.inspect} directly inside a nested meta tag Array is deprecated. " \
+              "It is rendered literally in MetaTags 2.x but will be interpreted as a mirrored reference in MetaTags 3.0. " \
+              "Set MetaTags.config.resolve_symbolic_references_in_arrays = true to opt in now; this behavior will " \
+              "become the default in MetaTags 3.0. Use a String to keep a literal value."
+          )
+        end
+      end
+
       content.each { |value| process_tree(tags, property, value, itemprop: itemprop) }
+    end
+
+    # Resolves a Symbol reference and processes its normalized value once.
+    #
+    # @param tags [Array<Tag>] a buffer object to store tags in.
+    # @param property [String, Symbol] the meta tag property name.
+    # @param reference [Symbol] normalized top-level meta tag reference.
+    # @param itemprop [String, Symbol, nil] value of the itemprop attribute.
+    def process_reference(tags, property, reference, itemprop: nil)
+      content = normalized_meta_tags[reference]
+      case content
+      when Hash
+        process_hash(tags, property, content, itemprop: itemprop)
+      when Array
+        process_array(tags, property, content, itemprop: itemprop)
+      else
+        render_tag(tags, property, content, itemprop: itemprop)
+      end
     end
 
     # Renders a single meta tag.

--- a/sig/_private/rails_support.rbs
+++ b/sig/_private/rails_support.rbs
@@ -33,6 +33,11 @@ module ActionController
 end
 
 module ActiveSupport
+  class Deprecation
+    def initialize: (String deprecation_horizon, String gem_name) -> void
+    def warn: (String message) -> void
+  end
+
   class HashWithIndifferentAccess[unchecked out K, unchecked out V] < Hash[K, V]
     def with_indifferent_access: () -> self
     def deep_merge!: (instance | Hash[K, V] other) -> self

--- a/sig/lib/meta_tags.rbs
+++ b/sig/lib/meta_tags.rbs
@@ -2,8 +2,10 @@ module MetaTags
   type meta_tags = Hash[Renderer::meta_key, Renderer::meta_value]
 
   self.@config: Configuration
+  self.@deprecator: ActiveSupport::Deprecation?
 
   def self.config: () -> Configuration
+  def self.deprecator: () -> ActiveSupport::Deprecation
   def self.configure: () { (Configuration) -> void } -> void
 
   interface _Stringish

--- a/sig/lib/meta_tags/configuration.rbs
+++ b/sig/lib/meta_tags/configuration.rbs
@@ -16,6 +16,7 @@ module MetaTags
     attr_accessor keywords_lowercase: bool
     attr_accessor open_meta_tags: bool
     attr_accessor minify_output: bool
+    attr_accessor resolve_symbolic_references_in_arrays: bool
     attr_reader property_tags: Array[String | Symbol]
     attr_accessor skip_canonical_links_on_noindex: bool
 

--- a/sig/lib/meta_tags/renderer.rbs
+++ b/sig/lib/meta_tags/renderer.rbs
@@ -43,6 +43,8 @@ module MetaTags
 
     def process_array: (Array[Tag] tags, meta_key property, Array[meta_value] content, ?itemprop: meta_value itemprop) -> void
 
+    def process_reference: (Array[Tag] tags, meta_key property, Symbol reference, ?itemprop: meta_value itemprop) -> void
+
     def render_tag: (Array[Tag] tags, meta_key name, meta_content value, ?itemprop: meta_value itemprop) -> void
 
     def configured_name_key: (meta_key name) -> Symbol

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -13,4 +13,15 @@ RSpec.describe MetaTags::Configuration do
       expect(c).to be(MetaTags.config)
     end
   end
+
+  it "disables symbolic references in Array values by default" do
+    config = described_class.new
+
+    expect(config.resolve_symbolic_references_in_arrays).to be(false)
+
+    config.resolve_symbolic_references_in_arrays = true
+    config.reset_defaults!
+
+    expect(config.resolve_symbolic_references_in_arrays).to be(false)
+  end
 end

--- a/spec/view_helper/custom_spec.rb
+++ b/spec/view_helper/custom_spec.rb
@@ -4,6 +4,8 @@ require "spec_helper"
 
 RSpec.describe MetaTags::ViewHelper do
   describe "display any named meta tag that you want to" do
+    before { allow(MetaTags.deprecator).to receive(:warn) }
+
     it "displays testing meta tag" do
       subject.display_meta_tags(testing: "this is a test").tap do |meta|
         expect(meta).to have_tag("meta", with: {content: "this is a test", name: "testing"})
@@ -23,10 +25,108 @@ RSpec.describe MetaTags::ViewHelper do
       end
     end
 
-    it "supports symbolic references in Hash values" do
-      subject.display_meta_tags(title: "my title", testing: {tag: :title}).tap do |meta|
-        expect(meta).to have_tag("meta", with: {content: "my title", name: "testing:tag"})
-      end
+    it "resolves symbolic references in Hash values" do
+      meta = subject.display_meta_tags(title: "my title", testing: {tag: :title})
+
+      expect(meta).to eq(<<~HTML.chomp)
+        <title>my title</title>
+        <meta name="testing:tag" content="my title">
+      HTML
+      expect(MetaTags.deprecator).not_to have_received(:warn)
+    end
+
+    it "warns about symbolic reference candidates in Array values without changing their output" do
+      meta = subject.display_meta_tags(
+        image_src: "https://example.com/image.png",
+        og: {image: [:image_src]}
+      )
+
+      expect(meta).to eq(<<~HTML.chomp)
+        <link rel="image_src" href="https://example.com/image.png">
+        <meta property="og:image" content="image_src">
+      HTML
+      expect(MetaTags.deprecator).to have_received(:warn).once.with(
+        include(
+          ":image_src",
+          "rendered literally in MetaTags 2.x",
+          "MetaTags.config.resolve_symbolic_references_in_arrays = true",
+          "default in MetaTags 3.0"
+        )
+      )
+    end
+
+    it "resolves symbolic references in Array values when configured" do
+      MetaTags.config.resolve_symbolic_references_in_arrays = true
+
+      meta = subject.display_meta_tags(
+        description: "Image description",
+        image_src: "https://example.com/image.png",
+        og: {
+          image: [:image_src, {alt: [:description]}],
+          video: [:missing],
+          audio: :image_src
+        }
+      )
+
+      expect(meta).to eq(<<~HTML.chomp)
+        <meta name="description" content="Image description">
+        <link rel="image_src" href="https://example.com/image.png">
+        <meta property="og:image" content="https://example.com/image.png">
+        <meta property="og:image:alt" content="Image description">
+        <meta property="og:audio" content="https://example.com/image.png">
+      HTML
+      expect(MetaTags.deprecator).not_to have_received(:warn)
+    end
+
+    it "does not warn about literal Symbol values in Array values" do
+      meta = subject.display_meta_tags(article: {tag: [:ruby, :rails]})
+
+      expect(meta).to eq(<<~HTML.chomp)
+        <meta property="article:tag" content="ruby">
+        <meta property="article:tag" content="rails">
+      HTML
+      expect(MetaTags.deprecator).not_to have_received(:warn)
+    end
+
+    it "does not warn about top-level Symbol Array values" do
+      meta = subject.display_meta_tags(title: "my title", testing: [:title])
+
+      expect(meta).to eq(<<~HTML.chomp)
+        <title>my title</title>
+        <meta name="testing" content="title">
+      HTML
+      expect(MetaTags.deprecator).not_to have_received(:warn)
+    end
+
+    it "warns about symbolic reference candidates in nested Array values" do
+      meta = subject.display_meta_tags(
+        description: "Image description",
+        image_src: "https://example.com/image.png",
+        og: {image: [{_: :image_src, alt: [:description]}]}
+      )
+
+      expect(meta).to eq(<<~HTML.chomp)
+        <meta name="description" content="Image description">
+        <link rel="image_src" href="https://example.com/image.png">
+        <meta property="og:image" content="https://example.com/image.png">
+        <meta property="og:image:alt" content="description">
+      HTML
+      expect(MetaTags.deprecator).to have_received(:warn).once.with(
+        include(":description", "rendered literally in MetaTags 2.x", "mirrored reference in MetaTags 3.0")
+      )
+    end
+
+    it "preserves missing symbolic references without warnings" do
+      meta = subject.display_meta_tags(
+        og: {
+          image: :missing,
+          video: [:missing],
+          audio: [{_: :missing}]
+        }
+      )
+
+      expect(meta).to eq('<meta property="og:video" content="missing">')
+      expect(MetaTags.deprecator).not_to have_received(:warn)
     end
 
     it "does not render when value is nil" do

--- a/spec/view_helper/custom_spec.rb
+++ b/spec/view_helper/custom_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe MetaTags::ViewHelper do
       expect(MetaTags.deprecator).not_to have_received(:warn)
     end
 
-    it "warns about symbolic reference candidates in Array values without changing their output" do
+    it "warns about Symbol values in Array values without changing their output" do
       meta = subject.display_meta_tags(
         image_src: "https://example.com/image.png",
         og: {image: [:image_src]}
@@ -78,14 +78,29 @@ RSpec.describe MetaTags::ViewHelper do
       expect(MetaTags.deprecator).not_to have_received(:warn)
     end
 
-    it "does not warn about literal Symbol values in Array values" do
+    it "resolves existing Hash references only once when Array references are configured" do
+      MetaTags.config.resolve_symbolic_references_in_arrays = true
+
+      meta = subject.display_meta_tags(
+        image_src: :asset,
+        og: {image: {alt: :image_src}}
+      )
+
+      expect(meta).to eq(<<~HTML.chomp)
+        <link rel="image_src" href="asset">
+        <meta property="og:image:alt" content="asset">
+      HTML
+      expect(MetaTags.deprecator).not_to have_received(:warn)
+    end
+
+    it "warns about literal Symbol values in Array values" do
       meta = subject.display_meta_tags(article: {tag: [:ruby, :rails]})
 
       expect(meta).to eq(<<~HTML.chomp)
         <meta property="article:tag" content="ruby">
         <meta property="article:tag" content="rails">
       HTML
-      expect(MetaTags.deprecator).not_to have_received(:warn)
+      expect(MetaTags.deprecator).to have_received(:warn).once.with(include(":ruby"))
     end
 
     it "does not warn about top-level Symbol Array values" do
@@ -98,7 +113,7 @@ RSpec.describe MetaTags::ViewHelper do
       expect(MetaTags.deprecator).not_to have_received(:warn)
     end
 
-    it "warns about symbolic reference candidates in nested Array values" do
+    it "warns about Symbol values in nested Array values" do
       meta = subject.display_meta_tags(
         description: "Image description",
         image_src: "https://example.com/image.png",
@@ -116,7 +131,7 @@ RSpec.describe MetaTags::ViewHelper do
       )
     end
 
-    it "preserves missing symbolic references without warnings" do
+    it "warns about missing symbolic references only when nested directly in Arrays" do
       meta = subject.display_meta_tags(
         og: {
           image: :missing,
@@ -126,7 +141,7 @@ RSpec.describe MetaTags::ViewHelper do
       )
 
       expect(meta).to eq('<meta property="og:video" content="missing">')
-      expect(MetaTags.deprecator).not_to have_received(:warn)
+      expect(MetaTags.deprecator).to have_received(:warn).once.with(include(":missing"))
     end
 
     it "does not render when value is nil" do

--- a/spec/view_helper/module_spec.rb
+++ b/spec/view_helper/module_spec.rb
@@ -3,6 +3,12 @@
 require "spec_helper"
 
 RSpec.describe MetaTags::ViewHelper, "module" do
+  it "registers the MetaTags deprecator with Rails" do
+    skip "Rails.application.deprecators requires Rails 7.1+" unless Rails.application.respond_to?(:deprecators)
+
+    expect(Rails.application.deprecators[:meta_tags]).to be(MetaTags.deprecator)
+  end
+
   it "is mixed into ActionView::Base" do
     expect(ActionView::Base.included_modules).to include(described_class)
   end


### PR DESCRIPTION
### Why?

Symbol references already work in custom-tag hashes:

```ruby
display_meta_tags(
  image_src: "https://example.com/image.png",
  og: {image: :image_src}
)
```

This renders the normalized URL:

```html
<link rel="image_src" href="https://example.com/image.png">
<meta property="og:image" content="https://example.com/image.png">
```

The same reference inside an array currently renders literally:

```ruby
display_meta_tags(
  image_src: "https://example.com/image.png",
  og: {image: [:image_src]}
)
```

MetaTags 2.x renders:

```html
<link rel="image_src" href="https://example.com/image.png">
<meta property="og:image" content="image_src">
```

Symbol resolution happens while processing hash values, before array elements reach the scalar renderer. Reference semantics therefore depend on the containing data structure.

Changing arrays immediately would be unsafe because Symbols have also been valid literal array values:

```ruby
display_meta_tags(
  article: {tag: [:ruby, :rails]}
)
```

Resolving every Symbol without a transition period could remove or change existing metadata.

### How?

MetaTags 2.x preserves existing output by default and warns for every Symbol used directly inside a recursive custom-tag array. Applications can opt in to the planned MetaTags 3.0 behavior today, while Strings remain the unambiguous form for literal values.

#### Default MetaTags 2.x behavior

When a Symbol appears directly inside a recursive custom-tag array, MetaTags emits a deprecation warning but continues rendering the Symbol literally. This includes Symbols without a matching normalized value because they will stop rendering when the MetaTags 3.0 behavior is enabled.

For example:

```ruby
display_meta_tags(
  image_src: "https://example.com/image.png",
  og: {image: [:image_src]}
)
```

Still renders:

```html
<link rel="image_src" href="https://example.com/image.png">
<meta property="og:image" content="image_src">
```

It now also emits:

```text
DEPRECATION WARNING: Passing :image_src directly inside a nested meta tag Array is deprecated. It is rendered literally in MetaTags 2.x but will be interpreted as a mirrored reference in MetaTags 3.0. Set MetaTags.config.resolve_symbolic_references_in_arrays = true to opt in now; this behavior will become the default in MetaTags 3.0. Use a String to keep a literal value.
```

The gem uses its own `ActiveSupport::Deprecation` instance. Rails 7.1 and newer register it with `Rails.application.deprecators`, allowing applications to configure it through standard Rails deprecation settings.

#### Affected cases

Warnings are limited to cases whose meaning will change in MetaTags 3.0.

| Input | Warning | MetaTags 2.x default behavior |
|---|---:|---|
| `og: {image: [:image_src]}` with an `image_src` value | Yes | Renders `"image_src"` literally |
| `og: {image: [{alt: [:description]}]}` with a description | Yes | Renders `"description"` literally |
| `article: {tag: [:ruby, :rails]}` without matching normalized tags | Yes | Renders both Symbols literally |
| `og: {video: [:missing]}` | Yes | Renders `"missing"` literally |
| `og: {image: :image_src}` | No | Uses the existing direct-hash reference behavior |
| `og: {image: [{_: :image_src}]}` | No | Uses the existing explicit reference form |
| `testing: [:title]` | No | Remains a top-level literal array |
| A nested-array reference with the new option enabled | No | Uses the MetaTags 3.0 behavior |

Normalized targets include values prepared during rendering, such as `title`, `description`, `full_title`, `image_src`, and `canonical`.

Only recursive arrays inside custom-tag hashes are affected. Arrays used for titles, keywords, icons, alternate links, and top-level custom-tag values are outside this change.

#### Opting in today

Applications can adopt the planned MetaTags 3.0 behavior now:

```ruby
MetaTags.configure do |config|
  config.resolve_symbolic_references_in_arrays = true
end
```

With the option enabled:

```ruby
display_meta_tags(
  image_src: "https://example.com/image.png",
  og: {image: [:image_src]}
)
```

Renders:

```html
<link rel="image_src" href="https://example.com/image.png">
<meta property="og:image" content="https://example.com/image.png">
```

References also resolve inside deeper recursive shapes:

```ruby
display_meta_tags(
  description: "Image description",
  image_src: "https://example.com/image.png",
  og: {
    image: [
      :image_src,
      {alt: [:description]}
    ]
  }
)
```

Renders:

```html
<meta name="description" content="Image description">
<link rel="image_src" href="https://example.com/image.png">
<meta property="og:image" content="https://example.com/image.png">
<meta property="og:image:alt" content="Image description">
```

Under the new behavior, a missing Symbol reference does not render a tag, matching existing direct-hash reference semantics:

```ruby
display_meta_tags(
  og: {video: [:missing]}
)
```

Applications that intend literal values should replace Symbols with Strings:

```ruby
display_meta_tags(
  article: {tag: ["ruby", "rails"]}
)
```

#### MetaTags 3.0 roadmap

1. MetaTags 2.x keeps `resolve_symbolic_references_in_arrays` disabled by default and preserves current rendering.
2. Every direct nested-array Symbol emits a targeted deprecation warning, including literal and missing values that will stop rendering under the new behavior.
3. Applications can enable the option early, update literal Symbols to Strings, and verify their generated metadata before upgrading.
4. MetaTags 3.0 will enable the new behavior by default, making Symbol reference semantics consistent across hashes and recursive arrays.

Existing direct-hash Symbol references remain supported throughout this transition.
