### PR TITLE
Preserve itemprop during recursive rendering

### DIFF
--- a/lib/meta_tags/renderer.rb
+++ b/lib/meta_tags/renderer.rb
@@ -229,8 +229,12 @@ module MetaTags
     # @param content [Hash] nested meta tag attributes.
     # @param itemprop [String, Symbol, nil] inherited itemprop value.
     def process_hash(tags, property, content, itemprop: nil)
-      current_itemprop = content.delete(:itemprop)
+      itemprop_key = content.key?(:itemprop) ? :itemprop : "itemprop"
+      current_itemprop = content.key?(itemprop_key) ? content[itemprop_key] : itemprop
+
       content.each do |key, value|
+        next if key.to_s == "itemprop"
+
         if key.to_s == "_"
           key = property
           next_itemprop = current_itemprop

--- a/spec/view_helper/custom_spec.rb
+++ b/spec/view_helper/custom_spec.rb
@@ -176,6 +176,41 @@ RSpec.describe MetaTags::ViewHelper do
       end
     end
 
+    it "preserves itemprop and collection state across renders" do
+      subject.set_meta_tags(og: {image: {_: "image.png", itemprop: "image"}})
+      original_meta_tags = subject.meta_tags.meta_tags.deep_dup
+
+      first_render = subject.display_meta_tags
+      second_render = subject.display_meta_tags
+
+      expect(first_render).to eq('<meta property="og:image" content="image.png" itemprop="image">')
+      expect(second_render).to eq(first_render)
+      expect(subject.meta_tags.meta_tags).to eq(original_meta_tags)
+    end
+
+    it "inherits itemprop through anonymous containers only" do
+      meta = subject.display_meta_tags(
+        twitter: {
+          image: {
+            _: [
+              "direct.png",
+              {_: "wrapped.png"},
+              {_: "overridden.png", itemprop: "custom"},
+              {alt: {_: "description"}}
+            ],
+            itemprop: "image"
+          }
+        }
+      )
+
+      expect(meta).to eq(<<~HTML.chomp)
+        <meta name="twitter:image" content="direct.png" itemprop="image">
+        <meta name="twitter:image" content="wrapped.png" itemprop="image">
+        <meta name="twitter:image" content="overridden.png" itemprop="custom">
+        <meta name="twitter:image:alt" content="description">
+      HTML
+    end
+
     it "displays meta tags with hashes and arrays" do
       test_hashes_and_arrays
     end


### PR DESCRIPTION
### Why?

`itemprop` attached to an anonymous custom tag is lost when recursive rendering crosses an inner hash. Equivalent scalar and structured entries therefore render differently, while structured image arrays omit the expected attribute entirely. The traversal also removes the reserved key from shared collection state.

#### Structured image arrays

Given multiple structured Open Graph images:

```ruby
set_meta_tags(
  og: {
    image: {
      _: [
        {
          _: "https://example.com/cover.jpg",
          width: 1200,
          height: 630
        },
        {
          _: "https://example.com/square.jpg",
          width: 1200,
          height: 1200
        }
      ],
      itemprop: "image"
    }
  }
)
```

Before this change, both anonymous image values lose the inherited attribute:

```html
<meta property="og:image" content="https://example.com/cover.jpg">
<meta property="og:image:width" content="1200">
<meta property="og:image:height" content="630">
<meta property="og:image" content="https://example.com/square.jpg">
<meta property="og:image:width" content="1200">
<meta property="og:image:height" content="1200">
```

After this change, each anonymous image inherits `itemprop`, while its named subproperties do not:

```html
<meta property="og:image" content="https://example.com/cover.jpg" itemprop="image">
<meta property="og:image:width" content="1200">
<meta property="og:image:height" content="630">
<meta property="og:image" content="https://example.com/square.jpg" itemprop="image">
<meta property="og:image:width" content="1200">
<meta property="og:image:height" content="1200">
```

#### Scalar and structured values

The inconsistency is also visible when scalar and structured values appear in the same array:

```ruby
set_meta_tags(
  og: {
    image: {
      _: [
        "https://example.com/cover.jpg",
        {
          _: "https://example.com/square.jpg",
          width: 1200,
          height: 1200
        }
      ],
      itemprop: "image"
    }
  }
)
```

Before this change, only the scalar value inherits `itemprop`:

```html
<meta property="og:image" content="https://example.com/cover.jpg" itemprop="image">
<meta property="og:image" content="https://example.com/square.jpg">
<meta property="og:image:width" content="1200">
<meta property="og:image:height" content="1200">
```

After this change, equivalent anonymous values behave consistently:

```html
<meta property="og:image" content="https://example.com/cover.jpg" itemprop="image">
<meta property="og:image" content="https://example.com/square.jpg" itemprop="image">
<meta property="og:image:width" content="1200">
<meta property="og:image:height" content="1200">
```

### How?

Read the reserved `itemprop` key without removing it and use the inherited value when an anonymous container does not provide an explicit override. Explicit nested values continue to take precedence, and named subproperties continue not to inherit the attribute.
