### PR TITLE
Suppress blank icon and alternate link URLs

### DIFF
--- a/lib/meta_tags/renderer.rb
+++ b/lib/meta_tags/renderer.rb
@@ -77,7 +77,7 @@ module MetaTags
 
       icon.each do |icon_params|
         icon_params = {rel: "icon", type: "image/x-icon"}.with_indifferent_access.merge(icon_params)
-        tags << Tag.new(:link, icon_params)
+        tags << Tag.new(:link, icon_params) if icon_params[:href].present?
       end
     end
 
@@ -123,7 +123,8 @@ module MetaTags
         end
       elsif alternate.is_a?(Array)
         alternate.each do |link_params|
-          tags << Tag.new(:link, {rel: "alternate"}.with_indifferent_access.merge(link_params))
+          link_params = {rel: "alternate"}.with_indifferent_access.merge(link_params)
+          tags << Tag.new(:link, link_params) if link_params[:href].present?
         end
       end
     end

--- a/spec/view_helper/icon_spec.rb
+++ b/spec/view_helper/icon_spec.rb
@@ -41,4 +41,27 @@ RSpec.describe MetaTags::ViewHelper do
       expect(meta).to have_tag("link", with: {href: "/images/icons/icon_itouch_precomp_32.png", rel: "apple-touch-icon-precomposed", type: "image/png", sizes: "32x32"})
     end
   end
+
+  [
+    ["nil", nil, false],
+    ["an empty string", "", false],
+    ["whitespace", " \t", false],
+    ["a valid URL", "/favicon.ico", true]
+  ].each do |description, href, renders|
+    {
+      "a scalar" => -> { href },
+      "a hash" => -> { {href: href} },
+      "an array" => -> { [{href: href}] }
+    }.each do |representation, icon|
+      it "#{renders ? "displays" : "does not display"} #{representation} icon with #{description}" do
+        subject.display_meta_tags(site: "someSite", icon: icon.call).tap do |meta|
+          if renders
+            expect(meta).to have_tag("link", with: {href: href, rel: "icon", type: "image/x-icon"})
+          else
+            expect(meta).not_to have_tag("link", with: {rel: "icon"})
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/view_helper/links_spec.rb
+++ b/spec/view_helper/links_spec.rb
@@ -115,6 +115,26 @@ RSpec.describe MetaTags::ViewHelper do
         expect(meta).to have_tag("link", with: {href: "http://m.example.com/page-1", media: "only screen and (max-width: 640px)", rel: "alternate"})
       end
     end
+
+    [
+      ["nil", nil, false],
+      ["an empty string", "", false],
+      ["whitespace", " \t", false],
+      ["a valid URL", "http://example.fr/base/url", true]
+    ].each do |description, href, renders|
+      it "renders hash and array representations identically with #{description}" do
+        hash_meta = subject.display_meta_tags(site: "someSite", alternate: {"fr" => href})
+        array_meta = subject.display_meta_tags(site: "someSite", alternate: [{href: href, hreflang: "fr"}])
+
+        expect(array_meta).to eq(hash_meta)
+
+        if renders
+          expect(array_meta).to have_tag("link", with: {href: href, hreflang: "fr", rel: "alternate"})
+        else
+          expect(array_meta).not_to have_tag("link", with: {rel: "alternate"})
+        end
+      end
+    end
   end
 
   describe "displaying prev url" do


### PR DESCRIPTION
### Why?

Dynamically generated icon and alternate URLs can resolve to nil or blank values. Those values previously produced unusable link elements instead of suppressing the link.

For example, an empty icon URL:

```erb
<%= display_meta_tags(icon: "") %>
```

produced:

```html
<link rel="icon" type="image/x-icon" href="">
```

An empty array-form alternate URL had the same problem:

```erb
<%= display_meta_tags(
  alternate: [{href: "", hreflang: "en"}]
) %>
```

and produced:

```html
<link rel="alternate" href="" hreflang="en">
```

The icon output can make browsers request the current document as the icon, while the alternate output cannot identify another resource. Canonical, OpenSearch, standard links, and hash-form alternates already suppress blank URLs.

### How?

Require a present URL after normalizing each supported icon or alternate representation. This aligns hash and array alternate behavior while preserving valid custom link attributes.
