### PR TITLE
Fix page title when site is supplied through defaults

### DIFF
--- a/lib/meta_tags/meta_tags_collection.rb
+++ b/lib/meta_tags/meta_tags_collection.rb
@@ -70,13 +70,10 @@ module MetaTags
     # @param defaults [Hash] list of default meta tag attributes.
     # @return [String] page title.
     def page_title(defaults = {})
-      had_site = @meta_tags.key?(:site)
-      old_site = @meta_tags[:site]
-      @meta_tags[:site] = nil if had_site
-      full_title = with_defaults(defaults) { extract_full_title }
-      full_title.presence || old_site || ""
-    ensure
-      @meta_tags[:site] = old_site if had_site
+      with_defaults(defaults) do
+        site = extract(:site)
+        extract_full_title.presence || site || ""
+      end
     end
 
     # Deletes and returns a meta tag value by name.

--- a/spec/meta_tags_collection_spec.rb
+++ b/spec/meta_tags_collection_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe MetaTags::MetaTagsCollection do
+  subject(:collection) { described_class.new }
+
+  describe "#page_title" do
+    it "excludes a site supplied through defaults" do
+      defaults = {site: "Default Site", title: "Default Page"}
+
+      expect(collection.page_title(defaults)).to eq("Default Page")
+      expect(collection.full_title(defaults)).to eq("Default Site | Default Page")
+    end
+
+    it "uses stored site and title values ahead of defaults" do
+      collection.update(site: "Stored Site", title: "Stored Page")
+      defaults = {site: "Default Site", title: "Default Page"}
+
+      expect(collection.page_title(defaults)).to eq("Stored Page")
+      expect(collection.full_title(defaults)).to eq("Stored Site | Stored Page")
+    end
+
+    it "combines stored and default values by precedence" do
+      collection.update(site: "Stored Site")
+      defaults = {site: "Default Site", title: "Default Page"}
+
+      expect(collection.page_title(defaults)).to eq("Default Page")
+      expect(collection.full_title(defaults)).to eq("Stored Site | Default Page")
+
+      collection = described_class.new
+      collection.update(title: "Stored Page")
+
+      expect(collection.page_title(defaults)).to eq("Stored Page")
+      expect(collection.full_title(defaults)).to eq("Default Site | Stored Page")
+    end
+
+    it "falls back to the effective site when the page title is empty" do
+      collection.update(site: "Stored Site", title: "")
+
+      expect(collection.page_title(site: "Default Site", title: "Default Page")).to eq("Stored Site")
+      expect(described_class.new.page_title(site: "Default Site", title: "")).to eq("Default Site")
+    end
+
+    it "applies reverse ordering and custom separators without including the site" do
+      defaults = {
+        site: "Default Site",
+        title: ["First", "Second"],
+        separator: ":",
+        prefix: " -",
+        suffix: "+ ",
+        reverse: true
+      }
+
+      expect(collection.page_title(defaults)).to eq("Second -:+ First")
+    end
+
+    it "restores the collection after repeated calls and exceptions" do
+      collection.update(site: "Stored Site", title: "Stored Page", separator: "/")
+      original_meta_tags = collection.meta_tags
+      original_values = original_meta_tags.deep_dup
+
+      expect(collection.page_title(site: "Default Site")).to eq("Stored Page")
+      expect(collection.page_title(site: "Default Site")).to eq("Stored Page")
+      expect(collection.meta_tags).to be(original_meta_tags)
+      expect(collection.meta_tags).to eq(original_values)
+
+      allow(MetaTags::TextNormalizer).to receive(:normalize_title).and_raise("normalization failed")
+
+      expect {
+        collection.page_title(site: "Default Site", title: "Default Page")
+      }.to raise_error("normalization failed")
+      expect(collection.meta_tags).to be(original_meta_tags)
+      expect(collection.meta_tags).to eq(original_values)
+    end
+  end
+end


### PR DESCRIPTION
### Why?

`MetaTagsCollection#page_title` is documented to return the title without the site, while `full_title` includes it. A site supplied only through defaults bypasses the existing suppression because defaults are merged afterward.

This example reproduces the problem:

```ruby
require "action_controller"
require "meta_tags"

collection = MetaTags::MetaTagsCollection.new

p collection.page_title(site: "Site", title: "Page")
p collection.full_title(site: "Site", title: "Page")
```

Before this change, both methods return:

```text
"Site | Page"
"Site | Page"
```

`page_title` should return `"Page"`, while `full_title` should continue returning `"Site | Page"`.

### How?

Build page-title extraction from the temporary effective collection after defaults are merged, excluding the effective site while retaining it for the existing empty-title fallback. The original collection is still restored after successful calls and exceptions.
