### PR TITLE
Suppress canonical links for custom noindex directives

### DIFF
--- a/lib/meta_tags/meta_tags_collection.rb
+++ b/lib/meta_tags/meta_tags_collection.rb
@@ -134,10 +134,43 @@ module MetaTags
       TextNormalizer.safe_join([prefix, separator, suffix], "")
     end
 
-    # Extracts noindex settings as a Hash mapping noindex tag name to value.
+    # Extracts robots settings as a Hash mapping tag names to rendered values.
     #
-    # @return [Hash{String => String}] noindex attributes.
+    # @return [Hash{String => String}] robots attributes.
     def extract_robots
+      result = robots
+      delete(:noindex, :index, :follow, :nofollow, :noarchive)
+      [:robots, :googlebot, :bingbot].each do |bot|
+        extract(bot) if meta_tags[bot].is_a?(Hash)
+      end
+
+      result
+    end
+
+    # Returns whether robots settings produce a noindex directive.
+    #
+    # @return [Boolean] true when a noindex directive will be rendered.
+    def noindex?
+      contents = robots.values
+      property_tags = MetaTags.config.property_tags.map(&:to_s)
+      [:robots, :googlebot, :bingbot].each do |bot|
+        values = meta_tags[bot]
+        next if values.is_a?(Hash) || property_tags.include?(bot.to_s)
+
+        contents.concat(Array(values))
+      end
+
+      contents.any? do |content|
+        content.to_s.split(",").any? { |directive| directive.strip.casecmp?("noindex") }
+      end
+    end
+
+    protected
+
+    # Returns robots settings without modifying the collection.
+    #
+    # @return [Hash{String => String}] robots attributes.
+    def robots
       # @type var result: Hash[String, Array[String]]
       result = Hash.new { |h, k| h[k] = [] }
 
@@ -153,28 +186,18 @@ module MetaTags
 
       [:robots, :googlebot, :bingbot].each do |bot|
         values = meta_tags[bot]
-        next unless values.is_a?(Hash)
+        if values.is_a?(Hash)
+          values.each do |key, value|
+            next if value == false
 
-        extract(bot)
-        values.each do |key, value|
-          next if value == false
-
-          directive = (value.nil? || value == true) ? key.to_s : "#{key}:#{value}"
-          result[bot.to_s] << directive
+            directive = (value.nil? || value == true) ? key.to_s : "#{key}:#{value}"
+            result[bot.to_s] << directive
+          end
         end
       end
 
       result.transform_values { |v| v.join(", ") }
     end
-
-    # Returns whether noindex settings produce at least one robots directive.
-    #
-    # @return [Boolean] true when a noindex directive will be rendered.
-    def noindex?
-      robots_attribute_present?(meta_tags[:noindex])
-    end
-
-    protected
 
     # Converts input hash to HashWithIndifferentAccess and renames :open_graph to :og.
     #
@@ -199,10 +222,16 @@ module MetaTags
     # Extracts a robots attribute name/value pair (noindex, nofollow, etc.).
     #
     # @param name [String, Symbol] noindex attribute name.
-    # @return [Array<String>] noindex attribute name and value pair.
+    # @return [Array<Object>] normalized robots tag name(s) and directive value.
     def extract_robots_attribute(name)
-      noindex = extract(name)
-      noindex_name = (noindex.is_a?(String) || noindex.is_a?(Array)) ? noindex : "robots"
+      noindex = meta_tags[name]
+      noindex_name = if noindex.is_a?(Array)
+        noindex.map(&:to_s)
+      elsif noindex.is_a?(String)
+        noindex
+      else
+        "robots"
+      end
       noindex_value = robots_attribute_present?(noindex) ? name.to_s : nil
 
       [noindex_name, noindex_value]
@@ -228,8 +257,8 @@ module MetaTags
         names, value = extract_robots_attribute(attribute)
         next unless value
 
-        Array(names).each do |name|
-          # @type var name: String | Symbol
+        robot_names = names.is_a?(String) ? [names] : names
+        robot_names.each do |name|
           apply_robots_value(result, name, value, processed)
         end
       end
@@ -238,7 +267,7 @@ module MetaTags
     # Records a robots directive unless it has already been set for the same key.
     #
     # @param result [Hash{String => Array<String>}] robots directives grouped by tag name.
-    # @param name [String, Symbol] robots tag name.
+    # @param name [String] robots tag name.
     # @param value [String] robots directive value.
     # @param processed [Set<String>] names already recorded in this pass.
     # @return [void]

--- a/sig/lib/meta_tags/meta_tags_collection.rbs
+++ b/sig/lib/meta_tags/meta_tags_collection.rbs
@@ -30,16 +30,18 @@ module MetaTags
 
     def noindex?: () -> bool
 
+    def robots: () -> Hash[String, String]
+
     def normalize_open_graph: (Hash[String | Symbol, untyped] meta_tags) -> ActiveSupport::HashWithIndifferentAccess[String | Symbol, untyped]
 
     def extract_separator_section: (String | Symbol name, String default) -> String
 
-    def extract_robots_attribute: (String | Symbol name) -> [String | Array[String | Symbol], String?]
+    def extract_robots_attribute: (String | Symbol name) -> [String | Array[String], String?]
 
     def robots_attribute_present?: (untyped value) -> bool
 
     def calculate_robots_attributes: (Hash[String, Array[String]] result, String | Symbol | Array[String | Symbol] attributes) -> void
 
-    def apply_robots_value: (Hash[String, Array[String]] result, String | Symbol name, String value, Set[String] processed) -> void
+    def apply_robots_value: (Hash[String, Array[String]] result, String name, String value, Set[String] processed) -> void
   end
 end

--- a/spec/view_helper/links_spec.rb
+++ b/spec/view_helper/links_spec.rb
@@ -72,6 +72,40 @@ RSpec.describe MetaTags::ViewHelper do
           end
         end
       end
+
+      [
+        ["the dedicated helper", {noindex: true}, '<meta name="robots" content="noindex">'],
+        ["a dedicated nil crawler", {noindex: [nil]}, '<meta name="" content="noindex">'],
+        ["a dedicated false crawler", {noindex: [false]}, '<meta name="false" content="noindex">'],
+        ["a structured directive", {robots: {noindex: true}}, '<meta name="robots" content="noindex">'],
+        ["a scalar directive", {robots: "noindex"}, '<meta name="robots" content="noindex">'],
+        [
+          "an array directive",
+          {robots: ["nofollow", "noindex"]},
+          %(<meta name="robots" content="nofollow">\n<meta name="robots" content="noindex">)
+        ],
+        [
+          "a disabled structured directive",
+          {robots: {noindex: false, follow: true}},
+          %(<link rel="canonical" href="http://example.com/base/url">\n<meta name="robots" content="follow">)
+        ],
+        ["a mixed-case directive", {robots: "NoIndex"}, '<meta name="robots" content="NoIndex">'],
+        ["a comma-separated directive", {robots: "follow, noindex"}, '<meta name="robots" content="follow, noindex">'],
+        [
+          "a bot-specific mixed-case array directive",
+          {googlebot: ["follow, NOINDEX"]},
+          '<meta name="googlebot" content="follow, NOINDEX">'
+        ],
+        [
+          "a near-match directive",
+          {robots: "noindexing"},
+          %(<link rel="canonical" href="http://example.com/base/url">\n<meta name="robots" content="noindexing">)
+        ]
+      ].each do |description, robots, expected|
+        it "keeps canonical and exact robots output aligned for #{description}" do
+          expect(subject.display_meta_tags({canonical: "http://example.com/base/url"}.merge(robots))).to eq(expected)
+        end
+      end
     end
   end
 

--- a/spec/view_helper/robots_spec.rb
+++ b/spec/view_helper/robots_spec.rb
@@ -67,4 +67,37 @@ RSpec.describe MetaTags::ViewHelper, "displaying robots meta tags" do
     expect(subject.display_meta_tags)
       .to eq('<meta name="googlebot" content="noindex, unavailable_after:2026-12-31">')
   end
+
+  it "preserves the legacy extraction contract for dedicated and scalar values" do
+    dedicated = MetaTags::MetaTagsCollection.new
+    dedicated.update(noindex: true)
+    expect(dedicated.extract_robots).to eq("robots" => "noindex")
+
+    scalar = MetaTags::MetaTagsCollection.new
+    scalar.update(robots: "noindex")
+    expect(scalar.extract_robots).to eq({})
+    expect(scalar[:robots]).to eq("noindex")
+  end
+
+  it "keeps scalar custom robots in generic rendering order with configured attributes" do
+    MetaTags.config.property_tags.push(:robots)
+    MetaTags.config.skip_canonical_links_on_noindex = true
+
+    expect(
+      subject.display_meta_tags(
+        canonical: "https://example.test/page",
+        robots: "noindex",
+        alternate: {en: "/en"}
+      )
+    )
+      .to eq(<<~HTML.chomp)
+        <link rel="canonical" href="https://example.test/page">
+        <link rel="alternate" href="/en" hreflang="en">
+        <meta property="robots" content="noindex">
+      HTML
+  end
+
+  it "omits blank structured directives" do
+    expect(subject.display_meta_tags(robots: {"" => nil})).to eq("")
+  end
 end


### PR DESCRIPTION
### Why?

When `skip_canonical_links_on_noindex` is enabled, supported custom `robots` forms can emit `noindex` while retaining a canonical link. That sends contradictory indexing signals, and makes canonical suppression depend on whether callers use the dedicated `noindex` helper or an equivalent custom robots directive.

### Before

Verified against `origin/main` at `e0993b7`:

```ruby
MetaTags.config.skip_canonical_links_on_noindex = true
canonical = "https://example.com/article"

display_meta_tags(canonical:, robots: {noindex: true})
display_meta_tags(canonical:, robots: "noindex")
display_meta_tags(canonical:, robots: ["nofollow", "noindex"])
```

The three calls produced:

```html
<!-- robots: {noindex: true} -->
<link rel="canonical" href="https://example.com/article">
<meta name="robots" content="noindex">

<!-- robots: "noindex" -->
<link rel="canonical" href="https://example.com/article">
<meta name="robots" content="noindex">

<!-- robots: ["nofollow", "noindex"] -->
<link rel="canonical" href="https://example.com/article">
<meta name="robots" content="nofollow">
<meta name="robots" content="noindex">
```

### After

The same Ruby calls now produce:

```html
<!-- robots: {noindex: true} -->
<meta name="robots" content="noindex">

<!-- robots: "noindex" -->
<meta name="robots" content="noindex">

<!-- robots: ["nofollow", "noindex"] -->
<meta name="robots" content="nofollow">
<meta name="robots" content="noindex">
```

### How?

Canonical suppression now evaluates the same normalized robots semantics used for rendering. It recognizes exact, case-insensitive `noindex` tokens across structured, scalar, array, comma-separated, and bot-specific directives while preserving existing extraction lifecycle, ordering, configured property-tag behavior, and disabled or near-match directives.
