### PR TITLE
Deep-merge og and open_graph aliases

### DIFF
--- a/lib/meta_tags/meta_tags_collection.rb
+++ b/lib/meta_tags/meta_tags_collection.rb
@@ -200,12 +200,20 @@ module MetaTags
     end
 
     # Converts input hash to HashWithIndifferentAccess and renames :open_graph to :og.
+    # When both aliases contain hashes, they are deep-merged with :og taking precedence.
     #
     # @param meta_tags [Hash] list of meta tags.
     # @return [ActiveSupport::HashWithIndifferentAccess] normalized meta tags list.
     def normalize_open_graph(meta_tags)
       meta_tags = meta_tags.with_indifferent_access
-      meta_tags[:og] = meta_tags.delete(:open_graph) if meta_tags.key?(:open_graph)
+      if meta_tags.key?(:open_graph)
+        open_graph = meta_tags.delete(:open_graph)
+        if meta_tags.key?(:og)
+          meta_tags[:og] = open_graph.dup.deep_merge!(meta_tags[:og]) if open_graph.is_a?(Hash) && meta_tags[:og].is_a?(Hash)
+        else
+          meta_tags[:og] = open_graph
+        end
+      end
       meta_tags
     end
 

--- a/spec/support/shared_examples_for_set_meta_tags.rb
+++ b/spec/support/shared_examples_for_set_meta_tags.rb
@@ -39,4 +39,62 @@ shared_examples_for ".set_meta_tags" do
     subject.set_meta_tags(open_graph: {title: "hello"})
     expect(subject.meta_tags[:og]).to eq("title" => "hello")
   end
+
+  context "when both Open Graph aliases are provided" do
+    [
+      [
+        "symbol keys with :og first",
+        {
+          og: {title: "canonical", image: {width: 120, height: 80}},
+          open_graph: {description: "alias", image: {width: 640, type: "image/png"}}
+        }
+      ],
+      [
+        "string keys with open_graph first",
+        {
+          "open_graph" => {"description" => "alias", "image" => {"width" => 640, "type" => "image/png"}},
+          "og" => {"title" => "canonical", "image" => {"width" => 120, "height" => 80}}
+        }
+      ]
+    ].each do |description, meta_tags|
+      it "deep-merges #{description} and gives :og precedence" do
+        subject.set_meta_tags(meta_tags)
+
+        expect(subject.meta_tags[:og]).to eq(
+          "title" => "canonical",
+          "description" => "alias",
+          "image" => {"width" => 120, "height" => 80, "type" => "image/png"}
+        )
+      end
+    end
+
+    it "does not mutate a HashWithIndifferentAccess value" do
+      open_graph = {description: "alias"}.with_indifferent_access.freeze
+
+      expect do
+        subject.set_meta_tags(og: {title: "canonical"}, open_graph: open_graph)
+      end.not_to raise_error
+      expect(open_graph).to eq("description" => "alias")
+    end
+  end
+
+  it "continues to give the later update precedence when switching from open_graph to og" do
+    subject.set_meta_tags(open_graph: {title: "first", image: {width: 120}})
+    subject.set_meta_tags(og: {title: "second", image: {height: 80}})
+
+    expect(subject.meta_tags[:og]).to eq(
+      "title" => "second",
+      "image" => {"width" => 120, "height" => 80}
+    )
+  end
+
+  it "continues to give the later update precedence when switching from og to open_graph" do
+    subject.set_meta_tags(og: {title: "first", image: {width: 120}})
+    subject.set_meta_tags(open_graph: {title: "second", image: {height: 80}})
+
+    expect(subject.meta_tags[:og]).to eq(
+      "title" => "second",
+      "image" => {"width" => 120, "height" => 80}
+    )
+  end
 end

--- a/spec/view_helper/open_graph_spec.rb
+++ b/spec/view_helper/open_graph_spec.rb
@@ -29,6 +29,16 @@ RSpec.describe MetaTags::ViewHelper, "displaying Open Graph meta tags" do
     end
   end
 
+  it "displays merged meta tags when both Open Graph aliases are specified" do
+    subject.display_meta_tags(
+      open_graph: {description: "Facebook Share Description"},
+      og: {title: "Facebook Share Title"}
+    ).tap do |meta|
+      expect(meta).to have_tag("meta", with: {content: "Facebook Share Title", property: "og:title"})
+      expect(meta).to have_tag("meta", with: {content: "Facebook Share Description", property: "og:description"})
+    end
+  end
+
   it "uses deep merge when displaying open graph meta tags" do
     subject.set_meta_tags(og: {title: "Facebook Share Title"})
     subject.display_meta_tags(og: {description: "Facebook Share Description"}).tap do |meta|


### PR DESCRIPTION
### Why?

Applications can combine metadata fragments that use both accepted Open Graph option names, `og` and `open_graph`. When both appeared in one input hash, normalization discarded the complete `og` value, silently losing valid metadata regardless of key order.

### How?

Normalize hash values from both aliases into one deep-merged `og` value. Canonical `og` values win duplicate leaves within the same input hash, while separate updates retain their existing last-update precedence and caller-owned hashes remain unchanged.

### Examples

These outputs were captured from this branch under the Rails 8.1 appraisal.

```ruby
collection = MetaTags::MetaTagsCollection.new
collection.update(
  open_graph: {
    description: "Long description",
    image: {type: "image/png", width: 640}
  },
  og: {
    title: "Short title",
    image: {width: 120, height: 80}
  }
)

pp collection.meta_tags
```

```ruby
{"og"=>
  {"description"=>"Long description",
   "image"=>{"type"=>"image/png", "width"=>120, "height"=>80},
   "title"=>"Short title"}}
```

Here, `open_graph` contributes the description and image type, while canonical `og` wins the conflicting image width.

Separate updates continue to use normal last-update precedence:

```ruby
collection = MetaTags::MetaTagsCollection.new
collection.update(og: {title: "First title", image: {width: 120}})
collection.update(open_graph: {title: "Second title", image: {height: 80}})

pp collection.meta_tags
```

```ruby
{"og"=>{"title"=>"Second title", "image"=>{"width"=>120, "height"=>80}}}
```
