### PR TITLE
Fix description limit RBS nullability

### DIFF
--- a/sig/lib/meta_tags/configuration.rbs
+++ b/sig/lib/meta_tags/configuration.rbs
@@ -10,7 +10,7 @@ module MetaTags
     attr_accessor truncate_on_natural_separator: String?|Regexp
     attr_accessor truncate_array_items_at_boundaries: bool
     attr_accessor title_tag_attributes: Hash[html_tag_key, html_tag_value]?
-    attr_accessor description_limit: Integer
+    attr_accessor description_limit: Integer?
     attr_accessor keywords_limit: Integer
     attr_accessor keywords_separator: String
     attr_accessor keywords_lowercase: bool

--- a/spec/text_normalizer/normalize_description_spec.rb
+++ b/spec/text_normalizer/normalize_description_spec.rb
@@ -3,17 +3,23 @@
 require "spec_helper"
 
 RSpec.describe MetaTags::TextNormalizer, ".normalize_description" do
-  let(:description) { "d" * (MetaTags.config.description_limit + 10) }
+  let(:description) { "d" * 20 }
 
-  it "truncates description when limit is reached" do
-    expect(subject.normalize_description(description)).to eq("d" * MetaTags.config.description_limit)
+  it "truncates description when limit is a positive integer" do
+    MetaTags.config.description_limit = 10
+
+    expect(subject.normalize_description(description)).to eq("d" * 10)
   end
 
-  it "does not truncate description when limit is 0 or nil" do
+  it "does not truncate description when limit is 0" do
     MetaTags.config.description_limit = 0
-    expect(subject.normalize_description(description)).to eq(description)
 
-    MetaTags.config.title_limit = nil
+    expect(subject.normalize_description(description)).to eq(description)
+  end
+
+  it "does not truncate description when limit is nil" do
+    MetaTags.config.description_limit = nil
+
     expect(subject.normalize_description(description)).to eq(description)
   end
 


### PR DESCRIPTION
### Why?

The generated initializer documents that `description_limit` accepts `nil` or `0` to disable truncation, and runtime behavior already honors both values. The RBS contract only accepted `Integer`, causing the documented `nil` configuration to fail under runtime type checking.

### How?

Align the `description_limit` accessor signature with the existing runtime contract by permitting `nil`, and strengthen normalization coverage so positive, zero, and nil limits are exercised independently.