### PR TITLE
Ignore blank robots crawler targets

### DIFF
--- a/lib/meta_tags/meta_tags_collection.rb
+++ b/lib/meta_tags/meta_tags_collection.rb
@@ -233,14 +233,17 @@ module MetaTags
     # @return [Array<Object>] normalized robots tag name(s) and directive value.
     def extract_robots_attribute(name)
       noindex = meta_tags[name]
+      # @type var noindex_name: String | Array[String]
       noindex_name = if noindex.is_a?(Array)
-        noindex.map(&:to_s)
+        noindex.reject { |target| target.is_a?(String) && target.blank? }.map(&:to_s)
       elsif noindex.is_a?(String)
-        noindex
+        noindex.presence || []
       else
         "robots"
       end
-      noindex_value = robots_attribute_present?(noindex) ? name.to_s : nil
+      noindex_value = if robots_attribute_present?(noindex) && noindex_name.present?
+        name.to_s
+      end
 
       [noindex_name, noindex_value]
     end

--- a/spec/view_helper/links_spec.rb
+++ b/spec/view_helper/links_spec.rb
@@ -74,6 +74,20 @@ RSpec.describe MetaTags::ViewHelper do
       end
 
       [
+        ["a blank crawler", "", '<link rel="canonical" href="http://example.com/base/url">'],
+        ["a whitespace-only crawler", " \t", '<link rel="canonical" href="http://example.com/base/url">'],
+        ["a blank crawler list", [""], '<link rel="canonical" href="http://example.com/base/url">'],
+        ["a whitespace-only crawler list", [" \t"], '<link rel="canonical" href="http://example.com/base/url">'],
+        ["blank and valid crawlers", ["", "googlebot", "  "], '<meta name="googlebot" content="noindex">'],
+        ["duplicate crawlers", ["googlebot", "googlebot"], '<meta name="googlebot" content="noindex">'],
+        ["a custom crawler", "examplebot", '<meta name="examplebot" content="noindex">']
+      ].each do |description, noindex, expected|
+        it "filters crawler targets and aligns exact output for #{description}" do
+          expect(subject.display_meta_tags(canonical: "http://example.com/base/url", noindex: noindex)).to eq(expected)
+        end
+      end
+
+      [
         ["the dedicated helper", {noindex: true}, '<meta name="robots" content="noindex">'],
         ["a dedicated nil crawler", {noindex: [nil]}, '<meta name="" content="noindex">'],
         ["a dedicated false crawler", {noindex: [false]}, '<meta name="false" content="noindex">'],


### PR DESCRIPTION
### Why?

Blank or whitespace-only `noindex` crawler targets were treated as present. On a normal page this replaced the canonical link with an invalid robots tag whose name browsers and crawlers ignore.

### How?

Blank String targets no longer produce robots directives or suppress canonical links. Mixed target arrays retain valid crawler names, while existing nil, false, non-string, duplicate, and custom-crawler behavior remains unchanged.

### Real-world rendering

This public-helper rendering was run unchanged against the current `main` branch and this pull request:

```ruby
MetaTags.config.skip_canonical_links_on_noindex = true

view = ActionController::Base.helpers
view.extend(MetaTags::ViewHelper)

puts view.display_meta_tags(
  title: "Algonquin Park Camping Guide",
  description: "Campsites, access points, and trip planning advice.",
  canonical: "https://example.com/guides/algonquin",
  noindex: ""
)
```

Before:

```html
<title>Algonquin Park Camping Guide</title>
<meta name="description" content="Campsites, access points, and trip planning advice.">
<meta name="" content="noindex">
```

The crawler ignores the empty-name meta tag, but the canonical link has already been suppressed.

After:

```html
<title>Algonquin Park Camping Guide</title>
<meta name="description" content="Campsites, access points, and trip planning advice.">
<link rel="canonical" href="https://example.com/guides/algonquin">
```
