### PR TITLE
Allow Rails tag option shapes in title attributes RBS

### DIFF
--- a/sig/lib/meta_tags/configuration.rbs
+++ b/sig/lib/meta_tags/configuration.rbs
@@ -1,8 +1,8 @@
 module MetaTags
   class Configuration
     type html_tag_key = String | Symbol
-    type html_tag_value = Hash[html_tag_key, html_tag_value] | html_tag_content
-    type html_tag_content = String? | Symbol | (_Stringish & Object)
+    type html_tag_value = Hash[html_tag_key, html_tag_value] | Array[html_tag_value] | html_tag_content
+    type html_tag_content = String? | Symbol | Numeric | bool | (_Stringish & Object)
 
 
     attr_accessor title_limit: Integer?

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -14,6 +14,18 @@ RSpec.describe MetaTags::Configuration do
     end
   end
 
+  it "accepts Rails tag option values for title tag attributes" do
+    attributes = {
+      class: ["page", ["permanent", {highlighted: true}]],
+      data: {page_id: 123, rating: 4.5, visible: false},
+      hidden: true
+    }
+
+    MetaTags.config.title_tag_attributes = attributes
+
+    expect(MetaTags.config.title_tag_attributes).to eq(attributes)
+  end
+
   it "disables symbolic references in Array values by default" do
     config = described_class.new
 


### PR DESCRIPTION
### Why?

`title_tag_attributes` is exposed as an HTML attribute hash and forwarded to ActionView at runtime, but its RBS contract rejects ordinary Rails tag options such as class arrays, numeric data values, and boolean attributes. Valid application configuration therefore fails runtime RBS checking even though Rails renders it correctly.

### Example

This valid Rails configuration was rejected by the previous RBS contract:

```ruby
MetaTags.config.title_tag_attributes = {
  class: ["page", "permanent"],
  data: {
    page_id: 123,
    tracking_enabled: true
  },
  hidden: false
}
```

With a title of `"Page"`, Rails renders:

```html
<title class="page permanent" data-page-id="123" data-tracking-enabled="true">Page</title>
```

The false boolean value correctly omits the `hidden` attribute.

### How?

Align the value type with documented recursive Rails tag-option shapes while retaining string and symbol key checking. Add runtime-RBS coverage for nested arrays and common numeric and boolean leaves without changing runtime behavior.
