### PR TITLE
Allow Float metadata in renderer type signatures

### DIFF
--- a/sig/lib/meta_tags/renderer.rbs
+++ b/sig/lib/meta_tags/renderer.rbs
@@ -2,7 +2,7 @@ module MetaTags
   class Renderer
     type meta_key = String | Symbol
     type meta_value = Hash[meta_key, meta_value] | Array[meta_value] | meta_content
-    type meta_content = String? | Symbol | Integer | bool | (_Timish & Object) | (_Stringish & Object)
+    type meta_content = String? | Symbol | Integer | Float | bool | (_Timish & Object) | (_Stringish & Object)
 
     attr_reader meta_tags: MetaTagsCollection
     attr_reader normalized_meta_tags: Hash[Symbol, meta_value]

--- a/spec/view_helper/custom_spec.rb
+++ b/spec/view_helper/custom_spec.rb
@@ -25,6 +25,24 @@ RSpec.describe MetaTags::ViewHelper do
       end
     end
 
+    it "supports finite Float values in recursive structures" do
+      meta = subject.display_meta_tags(
+        product: {
+          measurements: {
+            positive: 19.99,
+            negative: -2.5,
+            fractional: [0.125]
+          }
+        }
+      )
+
+      expect(meta).to eq(<<~HTML.chomp)
+        <meta property="product:measurements:positive" content="19.99">
+        <meta property="product:measurements:negative" content="-2.5">
+        <meta property="product:measurements:fractional" content="0.125">
+      HTML
+    end
+
     it "resolves symbolic references in Hash values" do
       meta = subject.display_meta_tags(title: "my title", testing: {tag: :title})
 


### PR DESCRIPTION
### Why?

MetaTags already renders finite `Float` values through Rails, but runtime RBS rejects the same metadata because the renderer's scalar type omits `Float`. This causes type failures at recursive renderer boundaries for otherwise valid metadata.

For example, this should behave the same with or without runtime RBS enabled:

```ruby
display_meta_tags(
  product: {
    price: {
      amount: 19.99
    }
  }
)
# => <meta property="product:price:amount" content="19.99">
```

### How?

Accept the concrete `Float` class at the existing scalar leaf while preserving the recursive hash and array structure. Cover representative finite positive, negative, and fractional values without broadening the contract to unvalidated numeric families.
