### PR TITLE
Fix lowercase title option handling

### DIFF
--- a/lib/meta_tags/meta_tags_collection.rb
+++ b/lib/meta_tags/meta_tags_collection.rb
@@ -107,12 +107,19 @@ module MetaTags
     #
     # @return [Array<String>] segments of page title.
     def extract_title
+      lowercase = extract(:lowercase) == true
       title = extract(:title).presence
       return [] unless title
 
-      # @type var title: Array[String]
       title = Array(title)
-      return title.map(&:downcase) if extract(:lowercase) == true
+      if lowercase
+        return title.map do |segment|
+          string = String.try_convert(segment)
+          raise ArgumentError, "Expected a string or an object that implements #to_str" unless string
+
+          string.downcase
+        end
+      end
 
       title
     end

--- a/spec/meta_tags_collection_spec.rb
+++ b/spec/meta_tags_collection_spec.rb
@@ -74,4 +74,14 @@ RSpec.describe MetaTags::MetaTagsCollection do
       expect(collection.meta_tags).to eq(original_values)
     end
   end
+
+  describe "#extract_title" do
+    it "only lowercases the raw value of a String-like title" do
+      string = "  <b>MiXeD</b>  "
+      collection.update(title: double(to_str: string), lowercase: true)
+
+      expect(collection.extract_title).to eq(["  <b>mixed</b>  "])
+      expect(string).to eq("  <b>MiXeD</b>  ")
+    end
+  end
 end

--- a/spec/view_helper/title_spec.rb
+++ b/spec/view_helper/title_spec.rb
@@ -10,6 +10,18 @@ RSpec.describe MetaTags::ViewHelper do
       expect(subject.display_meta_tags).to eq("")
     end
 
+    it "does not render :lowercase without a title" do
+      expect(subject.display_meta_tags(lowercase: true)).to eq("")
+    end
+
+    it "does not render :lowercase with a blank title" do
+      expect(subject.display_meta_tags(title: "", lowercase: true)).to eq("")
+    end
+
+    it "preserves site casing when :lowercase has no page title" do
+      expect(subject.display_meta_tags(site: "someSite", lowercase: true)).to eq("<title>someSite</title>")
+    end
+
     it "uses website name if title is empty" do
       subject.display_meta_tags(site: "someSite").tap do |meta|
         expect(meta).to eq("<title>someSite</title>")
@@ -103,6 +115,13 @@ RSpec.describe MetaTags::ViewHelper do
       expect(title).to eq("TITLE")
     end
 
+    it "lowercases a frozen title string" do
+      title = (+"TITLE").freeze
+
+      expect(subject.display_meta_tags(title: title, lowercase: true)).to eq("<title>title</title>")
+      expect(title).to eq("TITLE")
+    end
+
     it "uses custom separator when :separator specified" do
       subject.title("someTitle")
       subject.display_meta_tags(site: "someSite", separator: "-").tap do |meta|
@@ -169,6 +188,14 @@ RSpec.describe MetaTags::ViewHelper do
       end
     end
 
+    it "lowercases Arrays of objects that respond to #to_str in order" do
+      titles = [double(to_str: "FiRsT"), double(to_str: "SeCoNd")]
+
+      subject.display_meta_tags(site: "someSite", title: titles, lowercase: true).tap do |meta|
+        expect(meta).to eq("<title>someSite | first | second</title>")
+      end
+    end
+
     it "treats nil as an empty string" do
       subject.display_meta_tags(title: nil).tap do |meta|
         expect(meta).not_to have_tag("title")
@@ -182,11 +209,27 @@ RSpec.describe MetaTags::ViewHelper do
       end
     end
 
+    it "cleans and lowercases objects that respond to #to_str without changing their string" do
+      string = "<b>MiXeD</b>"
+      title = double(to_str: string)
+
+      expect(subject.display_meta_tags(title: title, lowercase: true)).to eq("<title>mixed</title>")
+      expect(string).to eq("<b>MiXeD</b>")
+    end
+
     it "fails when title is not a String-like object" do
       skip("Fails RBS") if ENV["RBS_TEST_TARGET"]
 
       expect {
         subject.display_meta_tags(site: "someSite", title: 5)
+      }.to raise_error ArgumentError, "Expected a string or an object that implements #to_str"
+    end
+
+    it "fails consistently when lowercasing a title that is not String-like" do
+      skip("Fails RBS") if ENV["RBS_TEST_TARGET"]
+
+      expect {
+        subject.display_meta_tags(site: "someSite", title: 5, lowercase: true)
       }.to raise_error ArgumentError, "Expected a string or an object that implements #to_str"
     end
 


### PR DESCRIPTION
### Why?

`:lowercase` is a title formatting control, but without a present page title it remained in the collection and rendered as a custom `<meta>` tag. Lowercasing also called `downcase` directly on supported objects that implement `#to_str`, raising `NoMethodError` instead of rendering their value.

### How?

Consume the formatting control before checking title presence, and coerce present title segments through the supported string-like protocol before applying non-mutating lowercasing. Title cleanup remains at its existing normalization boundary, preserving site casing and direct extraction behavior.

```ruby
string_like_title = Object.new
def string_like_title.to_str = "MiXeD"

display_meta_tags(site: "Site", lowercase: true)
# Before: <title>Site</title>
#         <meta name="lowercase" content="true">
# After:  <title>Site</title>

display_meta_tags(title: string_like_title, lowercase: true)
# Before: raises NoMethodError
# After:  <title>mixed</title>
```
