### PR TITLE
Install dependencies before releasing gem

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,8 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: false
+      - name: Install dependencies
+        run: bundle install
       - name: Setup private key
         env:
           GEM_PRIVATE_KEY: ${{ secrets.GEM_PRIVATE_KEY }}


### PR DESCRIPTION
### Why?

The 2.24.0 release workflow failed before building the gem with `Bundler::GemNotFound`. Disabling `bundler-cache` also removed `ruby/setup-ruby`'s implicit dependency installation, leaving `rubygems/release-gem` without the locked bundle it needs.

- https://github.com/kpumuk/meta-tags/actions/runs/33556885829/job/100020071826

### How?

Keep dependency caching disabled and explicitly install the release matrix bundle before the signing and publishing steps run.
