### PR TITLE
Register helper hooks when the gem loads, not on app boot

### DIFF
--- a/lib/meta_tags/railtie.rb
+++ b/lib/meta_tags/railtie.rb
@@ -1,22 +1,20 @@
 # frozen_string_literal: true
 
 module MetaTags
-  # Hooks MetaTags helpers into Rails controllers and views.
+  # Registers the MetaTags deprecator with the Rails application.
   class Railtie < Rails::Railtie
     initializer "meta_tags.register_deprecator", before: :load_environment_config do |app|
       app.deprecators[:meta_tags] = MetaTags.deprecator if app.respond_to?(:deprecators)
     end
+  end
 
-    initializer "meta_tags.setup_action_controller" do
-      ActiveSupport.on_load :action_controller do
-        include MetaTags::ControllerHelper
-      end
-    end
+  # Hooks MetaTags helpers into Rails controllers and views. Registering a load
+  # hook is lazy, so it does not have to wait for an application to boot.
+  ActiveSupport.on_load :action_controller do
+    include MetaTags::ControllerHelper
+  end
 
-    initializer "meta_tags.setup_action_view" do
-      ActiveSupport.on_load :action_view do
-        include MetaTags::ViewHelper
-      end
-    end
+  ActiveSupport.on_load :action_view do
+    include MetaTags::ViewHelper
   end
 end

--- a/spec/railtie_spec.rb
+++ b/spec/railtie_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe MetaTags::Railtie do
+  it "hooks helpers into Rails when the gem is loaded without an application boot" do
+    script = <<~RUBY
+      require "logger" # Required for Rails <= 7.0 on Ruby >= 3.1
+      require "action_controller/railtie"
+      require "action_view/railtie"
+      require "meta_tags"
+
+      abort "MetaTags::ControllerHelper is missing" unless ActionController::Base.included_modules.include?(MetaTags::ControllerHelper)
+      abort "MetaTags::ViewHelper is missing" unless ActionView::Base.included_modules.include?(MetaTags::ViewHelper)
+    RUBY
+
+    loaded = system(RbConfig.ruby, "-I", File.expand_path("../lib", __dir__), "-e", script)
+
+    expect(loaded).to be(true)
+  end
+end


### PR DESCRIPTION
### What

Move the two `ActiveSupport.on_load` calls in `lib/meta_tags/railtie.rb` out of their railtie initializers to the top level of the same file.

### Why

A railtie initializer only runs during a full application boot. So anything that merely *loads* the gem without booting an app — a plain `require "meta_tags"` in `irb`, a doc generator, an editor, a static analyser — sees `ControllerHelper` and `ViewHelper` mixed into nothing, and `set_meta_tags` / `display_meta_tags` look undefined on the classes that actually carry them.

Registering an `on_load` hook is lazy: it queues a block and loads nothing, so it doesn't need to wait for an initializer. This seems to be the established idiom for framework mixins — `responders` has the same shape, a railtie kept for its config initializer plus a top-level hook for the mixin ([lib/responders.rb](https://github.com/heartcombo/responders/blob/main/lib/responders.rb)):

```ruby
ActiveSupport.on_load(:action_controller) do
  include ActionController::RespondWith
end
```

and `gon`, which installs a controller helper and a view helper just like meta-tags does, registers both at the top level too ([lib/gon/helpers.rb](https://github.com/gazay/gon/blob/master/lib/gon/helpers.rb)).

### No behavior change

- On a booted application the hooks still fire at exactly the same moment: when `ActionController::Base` / `ActionView::Base` load.
- `railtie.rb` is still only required when `Rails` is defined (`lib/meta_tags.rb`), so non-Rails users are unaffected.
- `meta_tags.register_deprecator` stays an initializer — it needs `app` and the `before: :load_environment_config` ordering — so the `Railtie` class remains.

### Tested

- Added `spec/railtie_spec.rb`: loads `action_controller/railtie`, `action_view/railtie` and `meta_tags` in a subprocess with no `Rails.application.initialize!`, and asserts both helpers ended up in `included_modules`. It fails on `main` ("MetaTags::ControllerHelper is missing") and passes with this change. The existing `controller_helper_spec.rb` "is mixed into ActionController::Base" example keeps covering the booted path.
- `bundle exec rake` — 324 examples, 0 failures.
- `bundle exec rake steep` — no type errors (`railtie.rb` is ignored by the Steepfile, and no `sig` file changes).
- `bundle exec standardrb lib/meta_tags/railtie.rb spec/railtie_spec.rb` — clean.
- I couldn't run `yard-lint`, it's pinned to `platform: :mri_33` and I'm on a newer Ruby locally.